### PR TITLE
Disables edit mode for mobile screens

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -14,6 +14,12 @@ const Home = () => {
   const reduxUser = useAppSelector((state) => state.userReducer.user);
   const [user, setUser] = useState(authUser || reduxUser);
   const { toggleOpenSidebar } = useAppSelector((state) => state.userReducer);
+  const [isMobile, setIsMobile] = useState<boolean>(false);
+
+  useEffect(() => {
+    if (window.innerWidth <= 768) setIsMobile(true);
+    else setIsMobile(false);
+  }, [window]);
 
   useEffect(() => {
     setUser(authUser || reduxUser);
@@ -26,7 +32,7 @@ const Home = () => {
       {user && (
         <>
           <Sidebar show={toggleOpenSidebar} userInfo={user} />
-          <Profile user={user} canEdit />
+          <Profile user={user} canEdit={!isMobile} />
         </>
       )}
     </Container>


### PR DESCRIPTION
Description & Technical Solution
- Removes edit mode for editing widgets on mobile devices. Creates 'isMobile' boolean state where WidgetContainer is rendered and passes it down to WidgetContainer.

Describe problems, if any, clearly and concisely.
- 'Mobile' sizing is set at 768px, which includes tablets. Not sure if we are accounting for tablets, but included them to be safe.

Summarize the impact to the system.
- Handles edit flow for mobile devices, forcing users to edit on desktop for better UX.

Please also include relevant motivation and context.
- Potential for rendering bugs when editing in mobile due to react-grid-layout, our defined breakpoints, and not having enough space on mobile.

Please include a summary of the technical solution and how it solves the problem.
- This PR simply adds a mobile check in '/app/page.tsx' and stores this in state via 'isMobile'. Then passes this piece of state to WidgetContainer so that it knows whether to allow editing or not.

# Checklist

- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ x ] Already rebased against main branch.

# Screenshots

Provide screenshots or videos of the changes made if any.
