### PR TITLE
u/cp/claim sorbet

### DIFF
--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -6,6 +6,7 @@ import { Notifications } from '@/components/header/notifications';
 import { useAppDispatch } from '@/redux/hook';
 import { setOpenSidebar } from '@/redux/userSlice';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import React from 'react';
 
 interface HeaderProps {
@@ -14,6 +15,8 @@ interface HeaderProps {
 
 export const Header = ({ isPublic = false }: HeaderProps) => {
   const dispatch = useAppDispatch();
+
+  const router = useRouter();
 
   return (
     <div className='bg-[#F2F3F7]'>
@@ -45,10 +48,16 @@ export const Header = ({ isPublic = false }: HeaderProps) => {
         )}
         {isPublic && (
           <div className='flex items-center justify-end gap-4'>
-            <Button className='font-semibold text-sm text-[#344054] leading-5 py-[10px] px-[14px] bg-white border border-[#D0D5DD]'>
+            <Button
+              onClick={() => router.push('/signup')}
+              className='font-semibold text-sm text-[#344054] leading-5 py-[10px] px-[14px] bg-white border border-[#D0D5DD]'
+            >
               Claim my Sorbet
             </Button>
-            <Button className='font-semibold text-sm text-white leading-5 py-[10px] px-[14px] bg-sorbet border border-[#7F56D9]'>
+            <Button
+              onClick={() => router.push('/signin')}
+              className='font-semibold text-sm text-white leading-5 py-[10px] px-[14px] bg-sorbet border border-[#7F56D9]'
+            >
               Login
             </Button>
           </div>

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 /* eslint-disable @next/next/no-img-element */
-import { Button } from '../ui/button';
 import { Notifications } from '@/components/header/notifications';
+import { Button } from '@/components/ui/button';
 import { useAuth } from '@/hooks';
 import { useAppDispatch } from '@/redux/hook';
 import { setOpenSidebar } from '@/redux/userSlice';

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -3,6 +3,7 @@
 /* eslint-disable @next/next/no-img-element */
 import { Button } from '../ui/button';
 import { Notifications } from '@/components/header/notifications';
+import { useAuth } from '@/hooks';
 import { useAppDispatch } from '@/redux/hook';
 import { setOpenSidebar } from '@/redux/userSlice';
 import Link from 'next/link';
@@ -14,6 +15,8 @@ interface HeaderProps {
 }
 
 export const Header = ({ isPublic = false }: HeaderProps) => {
+  const { user } = useAuth();
+
   const dispatch = useAppDispatch();
 
   const router = useRouter();
@@ -46,17 +49,17 @@ export const Header = ({ isPublic = false }: HeaderProps) => {
             </div>
           </div>
         )}
-        {isPublic && (
+        {isPublic && !user && (
           <div className='flex items-center justify-end gap-4'>
             <Button
               onClick={() => router.push('/signup')}
-              className='font-semibold text-sm text-[#344054] leading-5 py-[10px] px-[14px] bg-white border border-[#D0D5DD]'
+              className='font-semibold text-sm text-[#344054] leading-5 py-[10px] px-[14px] bg-white border border-[#D0D5DD] hover:bg-gray-100'
             >
               Claim my Sorbet
             </Button>
             <Button
               onClick={() => router.push('/signin')}
-              className='font-semibold text-sm text-white leading-5 py-[10px] px-[14px] bg-sorbet border border-[#7F56D9]'
+              className='font-semibold text-sm text-white leading-5 py-[10px] px-[14px] bg-sorbet border border-[#7F56D9] hover:bg-[#523BDF]'
             >
               Login
             </Button>

--- a/src/components/Header/header.tsx
+++ b/src/components/Header/header.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 /* eslint-disable @next/next/no-img-element */
+import { Button } from '../ui/button';
 import { Notifications } from '@/components/header/notifications';
 import { useAppDispatch } from '@/redux/hook';
 import { setOpenSidebar } from '@/redux/userSlice';
@@ -40,6 +41,16 @@ export const Header = ({ isPublic = false }: HeaderProps) => {
                 />
               </div>
             </div>
+          </div>
+        )}
+        {isPublic && (
+          <div className='flex items-center justify-end gap-4'>
+            <Button className='font-semibold text-sm text-[#344054] leading-5 py-[10px] px-[14px] bg-white border border-[#D0D5DD]'>
+              Claim my Sorbet
+            </Button>
+            <Button className='font-semibold text-sm text-white leading-5 py-[10px] px-[14px] bg-sorbet border border-[#7F56D9]'>
+              Login
+            </Button>
           </div>
         )}
       </div>


### PR DESCRIPTION
# Description & Technical Solution
- Adds CTAs for when a user visits another profile and is not signed in
- Adds a check in `header.tsx` for if a user is active or not (signed in users can also visit)

Describe problems, if any, clearly and concisely.
- No major problems, just want to clarify hover states later. Just put in some random ones that I thought looked good. Need to talk to Chris for those designs.

Summarize the impact to the system.
- Better flow for users who are new to the platform or want to connect, but aren't signed in

Please also include relevant motivation and context.
- testnet launch!

Please include a summary of the technical solution and how it solves the problem.
- Simply adds two buttons in `header.tsx` and routes the user to either `/signup` or `/signin` on click.

# Checklist

- [ x ] I have commented my code, particularly in hard-to-understand areas.
- [ x ] Already rebased against main branch.

# Screenshots

Provide screenshots or videos of the changes made if any.

<img width="1470" alt="Screenshot 2024-07-25 at 6 24 58 PM" src="https://github.com/user-attachments/assets/8558a287-c618-410b-8139-8921052565b0">
