### PR TITLE
Hotfix for connectionStatus bug

### DIFF
--- a/src/app/gigs/chat/chat-layout-minimal.tsx
+++ b/src/app/gigs/chat/chat-layout-minimal.tsx
@@ -63,6 +63,8 @@ export function ChatLayoutMinimal({
     // Channel will always be defined whenever this event is triggered bc it is triggered thru sendbird and
     // only runs when a channel is successfully found between two users
     onMessagesAdded: async (context, channel, messages) => {
+      // TODO: This is a quick fix, need to look into finding a better solution
+      await channel.refresh();
       // The user will always be the sender, we are just trying to get the id of the recipient so we can check online status
       const senderId = user?.id;
       const recipientId = user?.id === clientId ? freelanceId : clientId;


### PR DESCRIPTION
# Description & Technical Solution
- Refreshes channel every time a user sends a message so that we can see if the other user is `online` or `offline`.
- There was an issue where the `connectionStatus` would be stale and not properly update. Then a user would receive a message notification even though the chat is open.

[ x ] Rebase with main

# Screenshots

Provide screenshots or videos of the changes made if any (optional)
