### PR TITLE
Hotfix for sharing profiles

### DIFF
--- a/src/components/profile/profile-header.tsx
+++ b/src/components/profile/profile-header.tsx
@@ -1,6 +1,8 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
+import { Popover, PopoverTrigger } from '@/components/ui/popover';
 import { User } from '@/types';
+import { PopoverArrow, PopoverContent } from '@radix-ui/react-popover';
 import { SquareArrowOutUpRight } from 'lucide-react';
 import React from 'react';
 
@@ -19,6 +21,12 @@ export const ProfileHeader: React.FC<ProfileHeaderProps> = ({
   onHireMeClick,
   disableHireMe = false,
 }) => {
+  const handleUrlToClipboard = () => () => {
+    const username = user.accountId.split('.')[0];
+    const url = `${window.location.origin}/${username}`;
+    navigator.clipboard.writeText(window.location.href);
+  };
+
   return (
     <>
       <div className='flex justify-center'>
@@ -86,13 +94,21 @@ export const ProfileHeader: React.FC<ProfileHeaderProps> = ({
               Hire Me
             </Button> // Added onClick event for Hire Me button
           )}
-          <a
-            href='#'
-            className='text-[#573DF5] flex flex-row align-center gap-1 items-center'
-          >
-            <SquareArrowOutUpRight size={16} />
-            <span>Share</span>
-          </a>
+          <Popover>
+            <PopoverTrigger>
+              <Button
+                className='text-[#573DF5] flex flex-row align-center gap-1 items-center bg-inherit hover:bg-inherit'
+                onClick={handleUrlToClipboard()}
+              >
+                <SquareArrowOutUpRight size={16} />
+                <span>Share</span>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className='bg-gray-900 p-2 text-white text-sm rounded-md'>
+              <PopoverArrow className='w-4 h-2' />
+              Url copied to clipboard!
+            </PopoverContent>
+          </Popover>
         </div>
       )}
     </>

--- a/src/components/profile/profile-header.tsx
+++ b/src/components/profile/profile-header.tsx
@@ -1,8 +1,7 @@
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
-import { Popover, PopoverTrigger } from '@/components/ui/popover';
+import { Popover, PopoverTrigger, PopoverContent } from '@/components/ui/popover';
 import { User } from '@/types';
-import { PopoverArrow, PopoverContent } from '@radix-ui/react-popover';
 import { SquareArrowOutUpRight } from 'lucide-react';
 import React from 'react';
 
@@ -104,9 +103,12 @@ export const ProfileHeader: React.FC<ProfileHeaderProps> = ({
                 <span>Share</span>
               </Button>
             </PopoverTrigger>
-            <PopoverContent className='bg-gray-900 p-2 text-white text-sm rounded-md'>
-              <PopoverArrow className='w-4 h-2' />
-              Url copied to clipboard!
+            <PopoverContent
+              className='h-fit w-fit p-2 text-sm'
+              side='top'
+              sideOffset={0}
+            >
+              Link copied!
             </PopoverContent>
           </Popover>
         </div>


### PR DESCRIPTION
# Description & Technical Solution
- Implements allowing users to copy their link to their clipboard when clicking the 'Share' button on their profile.
- Uses window origin to grab the base url and then uses `Clipboard API` to copy to clipboard.

# Screenshots
![Screenshot 2024-08-13 at 2 55 42 AM](https://github.com/user-attachments/assets/cde962cd-6795-48b3-8c57-3704eeb2cd25)

Provide screenshots or videos of the changes made if any (optional)
