### PR TITLE
Fixes image overflow for image on 4x2 widget (SRBT-132)

### DIFF
--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -27,7 +27,7 @@ const schema = z.object({
     .string()
     .max(100, 'Bio must be at most 100 characters')
     .min(5, 'Bio must be at least 5 characters'),
-  city: z.string().min(1, 'Location is required'),
+  city: z.string(),
   tags: z.array(z.string()),
 });
 
@@ -258,11 +258,6 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
                     <LocationInput register={register} setValue={setValue} />
                   )}
                 />
-                {errors.city && (
-                  <p className='mt-1 text-xs text-red-500'>
-                    {errors.city.message}
-                  </p>
-                )}
               </div>
               <div className='item w-full'>
                 <label className='text-sm font-medium text-[#344054]'>

--- a/src/components/profile/profile-header.tsx
+++ b/src/components/profile/profile-header.tsx
@@ -45,12 +45,14 @@ export const ProfileHeader: React.FC<ProfileHeaderProps> = ({
             )}
           </div>
           <div className='flex flex-col items-center gap-1'>
-            <div className='flex items-center gap-1'>
-              <MarkerPin03 className='h-4 w-4 text-[#667085]' />
-              <span className='text-xs leading-[18px] text-[#667085]'>
-                {user.city}
-              </span>
-            </div>
+            {user.city && (
+              <div className='flex items-center gap-1'>
+                <MarkerPin03 className='h-4 w-4 text-[#667085]' />
+                <span className='text-xs leading-[18px] text-[#667085]'>
+                  {user.city}
+                </span>
+              </div>
+            )}
             <div className='flex justify-center'>
               <div className='lg:w-7/12'>
                 <h1 className='text-center text-4xl font-bold leading-[44px]'>

--- a/src/components/profile/widgets/add-widgets.tsx
+++ b/src/components/profile/widgets/add-widgets.tsx
@@ -1,3 +1,6 @@
+import { CircleHelp, ImagePlus,Link } from 'lucide-react';
+import React, { useState } from 'react';
+
 import { Spinner } from '@/components/common';
 import { InvalidAlert } from '@/components/profile';
 import { validateUrl } from '@/components/profile/widgets';
@@ -13,8 +16,6 @@ import {
   TooltipTrigger,
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
-import { Link, CircleHelp, ImagePlus } from 'lucide-react';
-import React, { useState } from 'react';
 
 interface AddWidgetsProps {
   addUrl: (url: string, image?: File | undefined) => void;
@@ -66,7 +67,13 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
       const fileSize = file.size / 1024 / 1024; // in MB
       const fileExtension = file.name.split('.').pop()?.toLowerCase();
 
-      if (validExtensions.includes(fileExtension!) && fileSize <= 10) {
+      if (!fileExtension) {
+        // This condition is hit if there is no file extension
+        showErrorInvalidImage(true);
+        return;
+      }
+
+      if (validExtensions.includes(fileExtension) && fileSize <= 10) {
         addUrl('https://storage.googleapis.com', file);
       } else {
         showErrorInvalidImage(true);
@@ -97,7 +104,7 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
       )}
 
       {errorInvalidImage && (
-        <div className={'animate-in slide-in-from-bottom-8 mb-2 z-0'}>
+        <div className="animate-in slide-in-from-bottom-8 mb-2 z-0">
           <InvalidAlert
             handleAlertVisible={(show: boolean) => showErrorInvalidImage(show)}
             title='Error uploading file'

--- a/src/components/profile/widgets/add-widgets.tsx
+++ b/src/components/profile/widgets/add-widgets.tsx
@@ -1,4 +1,4 @@
-import { CircleHelp, ImagePlus,Link } from 'lucide-react';
+import { CircleHelp, ImagePlus, Link } from 'lucide-react';
 import React, { useState } from 'react';
 
 import { Spinner } from '@/components/common';
@@ -84,9 +84,9 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
   const panelClass = loading ? 'opacity-70 pointer-events-none' : '';
 
   return (
-    <div className={`hidden md:block lg:w-[480px] isolate ${panelClass}`}>
+    <div className={`isolate hidden md:block lg:w-[480px] ${panelClass}`}>
       {error && (
-        <div className='animate-in slide-in-from-bottom-8 mb-2 z-0'>
+        <div className='animate-in slide-in-from-bottom-8 z-0 mb-2'>
           <InvalidAlert
             handleAlertVisible={(status: boolean) => {
               showError(status);
@@ -104,7 +104,7 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
       )}
 
       {errorInvalidImage && (
-        <div className="animate-in slide-in-from-bottom-8 mb-2 z-0">
+        <div className='animate-in slide-in-from-bottom-8 z-0 mb-2'>
           <InvalidAlert
             handleAlertVisible={(show: boolean) => showErrorInvalidImage(show)}
             title='Error uploading file'
@@ -117,11 +117,11 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
         </div>
       )}
       <div
-        className={`flex flex-row gap-2 lg:gap-4 bg-white p-2 lg:p-4 rounded-2xl w-full drop-shadow-xl z-10 ${panelClass}`}
+        className={`z-10 flex w-full flex-row gap-2 rounded-2xl bg-white p-2 drop-shadow-xl lg:gap-4 lg:p-4 ${panelClass}`}
       >
         <div
           className={cn(
-            'flex items-center border-2 lg:py-2 lg:px-3 py-1 px-2 rounded-2xl flex-grow',
+            'flex flex-grow items-center rounded-2xl border-2 px-2 py-1 lg:px-3 lg:py-2',
             error ? 'border-red-500' : 'border-gray-300'
           )}
         >
@@ -133,11 +133,11 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
               e.preventDefault();
               handleUrlSubmit();
             }}
-            className='w-full flex items-center flex-grow justify-between'
+            className='flex w-full flex-grow items-center justify-between'
           >
             <input
               type='text'
-              className='outline-none flex-1'
+              className='flex-1 outline-none'
               placeholder='paste link'
               onChange={handleUrlChange}
               value={url}
@@ -145,13 +145,13 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
             />
             <button
               type='submit'
-              className='cursor-pointer flex-none bg-[#573DF5] text-white px-4 text-xs lg:text-sm py-1 rounded-lg'
+              className='flex-none cursor-pointer rounded-lg bg-[#573DF5] px-4 py-1 text-xs text-white lg:text-sm'
               disabled={loading}
             >
               {loading ? <Spinner size='small' /> : <span>Add</span>}
             </button>
           </form>
-          <div className='ml-2 text-gray-500 cursor-pointer'>
+          <div className='ml-2 cursor-pointer text-gray-500'>
             <Popover>
               <PopoverTrigger asChild>
                 <CircleHelp size={20} />
@@ -161,7 +161,7 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
                   You can post a link from the following supported platforms and
                   click <b>Add</b>. The following platforms are supported:
                 </p>
-                <p className='font-semibold mt-2'>
+                <p className='mt-2 font-semibold'>
                   Dribbble, Behance, Spotify, Instagram, Soundcloud, YouTube,
                   Medium, Substack
                 </p>
@@ -174,7 +174,7 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
           <Tooltip>
             <TooltipTrigger asChild>
               <label
-                className={`cursor-pointer flex hover:text-sorbet align-center justify-center items-center ${panelClass} ${
+                className={`hover:text-sorbet align-center flex cursor-pointer items-center justify-center ${panelClass} ${
                   loading ? 'opacity-50' : ''
                 }`}
               >

--- a/src/components/profile/widgets/widget-container.tsx
+++ b/src/components/profile/widgets/widget-container.tsx
@@ -63,7 +63,6 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
   const [initialLayout, setInitialLayout] = useState<ExtendedWidgetLayout[]>(
     []
   );
-  const [containerWidth, setContainerWidth] = useState<number>(0);
   const [addingWidget, setAddingWidget] = useState<boolean>(false);
   const [cols, setCols] = useState<number>(8);
   const [error, setError] = useState<string | null>(null);
@@ -89,7 +88,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
 
     if (!userWidgets || userWidgets.length < 1) return [];
 
-    return userWidgets.map((widget: WidgetDto, i: number) => ({
+    return userWidgets.map((widget: WidgetDto) => ({
       i: widget.id,
       x: widget.layout.x,
       y: widget.layout.y,
@@ -103,7 +102,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
       redirectUrl: widget.redirectUrl,
       size: widget.size as WidgetSize,
     }));
-  }, [userId, editMode, userWidgetData]);
+  }, [editMode, userWidgetData]);
 
   const handleWidgetResize = (
     key: string,
@@ -260,14 +259,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
     }
   };
 
-  const handleWidgetDropStop = (
-    newLayout: Layout[],
-    oldItem: Layout,
-    newItem: Layout,
-    placeholder: Layout,
-    event: MouseEvent,
-    element: HTMLElement
-  ) => {
+  const handleWidgetDropStop = (newLayout: Layout[]) => {
     const extendedLayoutObjects: ExtendedWidgetLayout[] = newLayout.map(
       (item) => {
         const layoutItem = layout.find((layoutItem) => layoutItem.i === item.i);
@@ -346,7 +338,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
 
     setLayout((prevLayout) => {
       let maxY = 0;
-      return prevLayout.map((item, index) => {
+      return prevLayout.map((item) => {
         const { w, h } = getWidgetDimensions({
           breakpoint: currentBreakpoint,
           size: item.size,
@@ -362,12 +354,6 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
       });
     });
   }, [currentBreakpoint, initialLayout]);
-
-  useEffect(() => {
-    if (containerRef.current) {
-      setContainerWidth(containerRef.current.offsetWidth);
-    }
-  }, []);
 
   useEffect(() => {
     const calculateBreakpoint = () => {
@@ -391,7 +377,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
     window.addEventListener('resize', calculateBreakpoint);
 
     return () => window.removeEventListener('resize', calculateBreakpoint);
-  }, [window.innerWidth]);
+  }, [currentBreakpoint]);
 
   if (isUserWidgetPending)
     return (

--- a/src/components/profile/widgets/widget-container.tsx
+++ b/src/components/profile/widgets/widget-container.tsx
@@ -63,6 +63,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
   const [initialLayout, setInitialLayout] = useState<ExtendedWidgetLayout[]>(
     []
   );
+  const [containerWidth, setContainerWidth] = useState<number>(0);
   const [addingWidget, setAddingWidget] = useState<boolean>(false);
   const [cols, setCols] = useState<number>(8);
   const [error, setError] = useState<string | null>(null);
@@ -88,7 +89,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
 
     if (!userWidgets || userWidgets.length < 1) return [];
 
-    return userWidgets.map((widget: WidgetDto) => ({
+    return userWidgets.map((widget: WidgetDto, i: number) => ({
       i: widget.id,
       x: widget.layout.x,
       y: widget.layout.y,
@@ -102,7 +103,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
       redirectUrl: widget.redirectUrl,
       size: widget.size as WidgetSize,
     }));
-  }, [editMode, userWidgetData]);
+  }, [userId, editMode, userWidgetData]);
 
   const handleWidgetResize = (
     key: string,
@@ -259,7 +260,14 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
     }
   };
 
-  const handleWidgetDropStop = (newLayout: Layout[]) => {
+  const handleWidgetDropStop = (
+    newLayout: Layout[],
+    oldItem: Layout,
+    newItem: Layout,
+    placeholder: Layout,
+    event: MouseEvent,
+    element: HTMLElement
+  ) => {
     const extendedLayoutObjects: ExtendedWidgetLayout[] = newLayout.map(
       (item) => {
         const layoutItem = layout.find((layoutItem) => layoutItem.i === item.i);
@@ -338,7 +346,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
 
     setLayout((prevLayout) => {
       let maxY = 0;
-      return prevLayout.map((item) => {
+      return prevLayout.map((item, index) => {
         const { w, h } = getWidgetDimensions({
           breakpoint: currentBreakpoint,
           size: item.size,
@@ -354,6 +362,12 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
       });
     });
   }, [currentBreakpoint, initialLayout]);
+
+  useEffect(() => {
+    if (containerRef.current) {
+      setContainerWidth(containerRef.current.offsetWidth);
+    }
+  }, []);
 
   useEffect(() => {
     const calculateBreakpoint = () => {
@@ -377,7 +391,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
     window.addEventListener('resize', calculateBreakpoint);
 
     return () => window.removeEventListener('resize', calculateBreakpoint);
-  }, [currentBreakpoint]);
+  }, [window.innerWidth]);
 
   if (isUserWidgetPending)
     return (

--- a/src/components/profile/widgets/widget-link.tsx
+++ b/src/components/profile/widgets/widget-link.tsx
@@ -1,8 +1,9 @@
-import { WidgetHeader, ImageOverlay } from '@/components/profile/widgets/';
-import { cn } from '@/lib/utils';
-import { LinkWidgetContentType, WidgetSize } from '@/types';
 import { Link } from 'lucide-react';
 import React from 'react';
+
+import { ImageOverlay,WidgetHeader } from '@/components/profile/widgets/';
+import { cn } from '@/lib/utils';
+import { LinkWidgetContentType, WidgetSize } from '@/types';
 
 interface LinkWidgetProps {
   /** The content from link for the widget to render */

--- a/src/components/profile/widgets/widget-link.tsx
+++ b/src/components/profile/widgets/widget-link.tsx
@@ -1,7 +1,7 @@
 import { Link } from 'lucide-react';
 import React from 'react';
 
-import { ImageOverlay,WidgetHeader } from '@/components/profile/widgets/';
+import { ImageOverlay, WidgetHeader } from '@/components/profile/widgets/';
 import { cn } from '@/lib/utils';
 import { LinkWidgetContentType, WidgetSize } from '@/types';
 
@@ -89,7 +89,7 @@ const Icon: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = ({
     <img
       className={cn('size-[30px]', className)}
       src={src}
-      alt={'Icon for widget'}
+      alt='Icon for widget'
       width={30}
       height={30}
       {...rest}

--- a/src/components/profile/widgets/widget-link.tsx
+++ b/src/components/profile/widgets/widget-link.tsx
@@ -45,8 +45,8 @@ export const LinkWidget: React.FC<LinkWidgetProps> = ({ content, size }) => {
             <Icon src={iconUrl} />
             <Title>{title}</Title>
           </WidgetHeader>
-          <div className='flex flex-row gap-3 justify-end h-full'>
-            <BannerImage src={heroImageUrl} className='w-2/3' />
+          <div className='flex max-h-full flex-row justify-end gap-3 overflow-hidden'>
+            <BannerImage src={heroImageUrl} className='w-2/3 ' />
           </div>
         </WidgetLayout>
       );
@@ -67,7 +67,7 @@ export const LinkWidget: React.FC<LinkWidgetProps> = ({ content, size }) => {
 
 const Title: React.FC<React.PropsWithChildren> = (props) => {
   return (
-    <span className='text-secondary-foreground font-semibold text-sm flex-grow self-center'>
+    <span className='text-secondary-foreground flex-grow self-center text-sm font-semibold'>
       {props.children}
     </span>
   );
@@ -98,7 +98,7 @@ const Icon: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = ({
     // we should have a reset applying border-box. div should be size-8 rounded-xl after the rest if the icons change
     <Link
       className={cn(
-        'box-border size-[30px] p-1 bg-gray-300 rounded-md',
+        'box-border size-[30px] rounded-md bg-gray-300 p-1',
         className
       )}
     />
@@ -114,7 +114,7 @@ const WidgetLayout = React.forwardRef<
 >(({ className, ...props }, ref) => (
   <div
     ref={ref}
-    className={cn('h-full flex flex-col gap-3', className)}
+    className={cn('flex h-full flex-col gap-3', className)}
     {...props}
   />
 ));
@@ -129,7 +129,7 @@ const BannerImage: React.FC<{ src?: string; className?: string }> = ({
   return (
     <div
       className={cn(
-        `h-full w-full relative rounded-2xl overflow-hidden flex items-center justify-center`,
+        `relative flex h-full w-full items-center justify-center overflow-hidden rounded-2xl`,
         !src && 'bg-gray-200',
         className
       )}
@@ -139,12 +139,12 @@ const BannerImage: React.FC<{ src?: string; className?: string }> = ({
           <img
             src={src}
             alt='Banner image from url'
-            className='w-full h-full object-cover'
+            className='h-full w-full object-cover'
           />
           <ImageOverlay />
         </>
       ) : (
-        <span className='text-muted-foreground font-semibold text-sm'>
+        <span className='text-muted-foreground text-sm font-semibold'>
           Nothing to see here
         </span>
       )}


### PR DESCRIPTION
# Description & Technical Solution
- Fixes image overflow issue by adding `overflow-hidden` style to  div wrapping `BannerImage` component for 4x2 widget in `widget-link.tsx` file.
- Also fixes ESLint warnings in `widget-link.tsx`,`widget-container.tsx`, and `add-widgets.tsx`

# Implementation
![Screenshot 2024-08-30 at 12 56 05 AM](https://github.com/user-attachments/assets/db4d317c-d9ab-4301-8e6d-ede1f0ad2a7e)

# Original Bug
![Screenshot 2024-08-10 at 1 14 15 AM](https://github.com/user-attachments/assets/48d2a8a2-d014-4998-8184-6029cbf862cd)
