### PR TITLE
Updates instagram widget SRBT-140

### DIFF
--- a/src/components/profile/widgets/widget-container.tsx
+++ b/src/components/profile/widgets/widget-container.tsx
@@ -164,6 +164,10 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
 
       // We're adding a widget that is not a photo
       // So try to fetch required content from the url and persist that content in the database as a new widget
+      /**
+       * Any function that is called by getWidgetContent should throw a descriptive error upon failure using the RQ onError callback
+       * i.e. if we are calling getInstagramProfileMetadata, it should throw a descriptive error that would bubble up to the onError callback
+       */
       const widget = await getWidgetContent({ url: widgetUrl, type });
 
       // If you got the content, add the widget to the layout state and persist it in the database

--- a/src/components/profile/widgets/widget-container.tsx
+++ b/src/components/profile/widgets/widget-container.tsx
@@ -164,16 +164,7 @@ export const WidgetContainer: React.FC<WidgetContainerProps> = ({
 
       // We're adding a widget that is not a photo
       // So try to fetch required content from the url and persist that content in the database as a new widget
-      let widget: any;
-      try {
-        widget = await getWidgetContent({ url: widgetUrl, type });
-      } catch (error) {
-        toast({
-          title: 'Failed to add widget',
-          description: 'If the issue persists, contact support',
-        });
-        return;
-      }
+      const widget = await getWidgetContent({ url: widgetUrl, type });
 
       // If you got the content, add the widget to the layout state and persist it in the database
       const widgetToAdd: ExtendedWidgetLayout = {

--- a/src/components/profile/widgets/widget-instagram.tsx
+++ b/src/components/profile/widgets/widget-instagram.tsx
@@ -53,22 +53,11 @@ export const InstagramWidget: React.FC<InstagramWidgetType> = ({
           </div>
           <div>{localHeader}</div>
           <div className='relative flex-grow overflow-hidden'>
-            {content.isPrivate ? (
-              <>
-                <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
-                  This account is private
-                </span>
-              </>
-            ) : content.images.length > 0 ? (
-              <div className='grid grid-cols-3 gap-1'>
-                <ImageGallery images={content.images} heightClass='h-20' />
-                <ImageOverlay />
-              </div>
-            ) : (
-              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
-                No pics posted yet!
-              </span>
-            )}
+            <InstagramImageContent
+              {...content}
+              className='grid grid-cols-3 gap-1'
+              heightClass='h-20'
+            />
           </div>
         </div>
       );
@@ -81,20 +70,11 @@ export const InstagramWidget: React.FC<InstagramWidgetType> = ({
             <div>{localHeader}</div>
           </div>
           <div className='relative h-full w-full overflow-hidden rounded-xl bg-white text-black'>
-            {content.isPrivate ? (
-              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
-                This account is private
-              </span>
-            ) : content.images.length > 0 ? (
-              <div className='grid h-full w-full grid-cols-2 gap-2'>
-                <ImageGallery images={content.images} heightClass='h-44' />
-                <ImageOverlay />
-              </div>
-            ) : (
-              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
-                No pics posted yet!
-              </span>
-            )}
+            <InstagramImageContent
+              {...content}
+              className='grid h-full w-full grid-cols-2 gap-2'
+              heightClass='h-44'
+            />
           </div>
         </div>
       );
@@ -109,20 +89,11 @@ export const InstagramWidget: React.FC<InstagramWidgetType> = ({
             </div>
           </div>
           <div className='relative h-full w-1/2 overflow-hidden rounded-xl'>
-            {content.isPrivate ? (
-              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
-                This account is private
-              </span>
-            ) : content.images.length > 0 ? (
-              <div className='grid h-full w-full grid-cols-2 gap-2'>
-                <ImageGallery images={content.images} heightClass='h-20' />
-                <ImageOverlay />
-              </div>
-            ) : (
-              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
-                No pics posted yet!
-              </span>
-            )}
+            <InstagramImageContent
+              {...content}
+              className='grid h-full w-full grid-cols-2 gap-2'
+              heightClass='h-20'
+            />
           </div>
         </div>
       );
@@ -135,24 +106,11 @@ export const InstagramWidget: React.FC<InstagramWidgetType> = ({
           </div>
           <div>{localHeader}</div>
           <div className='relative mt-24 h-full w-full overflow-hidden rounded-xl'>
-            {content.isPrivate ? (
-              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
-                This account is private
-              </span>
-            ) : content.images.length > 0 ? (
-              <div className='grid h-full w-full grid-cols-2 gap-2'>
-                <ImageGallery images={content.images} heightClass='h-28' />
-                <ImageOverlay />
-              </div>
-            ) : (
-              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
-                No pics posted yet!
-              </span>
-            )}
-            <div className='grid h-full w-full grid-cols-2 gap-2'>
-              <ImageGallery images={content.images} heightClass='h-28' />
-              <ImageOverlay />
-            </div>
+            <InstagramImageContent
+              {...content}
+              className='grid h-full w-full grid-cols-2 gap-2'
+              heightClass='h-28'
+            />
           </div>
         </div>
       );
@@ -162,4 +120,35 @@ export const InstagramWidget: React.FC<InstagramWidgetType> = ({
   }
 
   return widgetLayout;
+};
+
+interface InstagramImageContentProps extends InstagramWidgetContentType {
+  className: string;
+  heightClass: string;
+}
+
+const InstagramImageContent = ({
+  isPrivate,
+  images,
+  className,
+  heightClass,
+}: InstagramImageContentProps) => {
+  return (
+    <>
+      {isPrivate ? (
+        <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
+          This account is private
+        </span>
+      ) : images.length > 0 ? (
+        <div className={className}>
+          <ImageGallery images={images} heightClass={heightClass} />
+          <ImageOverlay />
+        </div>
+      ) : (
+        <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
+          No pics posted yet!
+        </span>
+      )}
+    </>
+  );
 };

--- a/src/components/profile/widgets/widget-instagram.tsx
+++ b/src/components/profile/widgets/widget-instagram.tsx
@@ -1,7 +1,6 @@
 import { ImageOverlay } from '@/components/profile/widgets';
 import { WidgetIcon } from '@/components/profile/widgets';
 import { InstagramWidgetContentType, WidgetSize } from '@/types';
-import React from 'react';
 
 interface InstagramWidgetType {
   content: InstagramWidgetContentType;
@@ -16,21 +15,19 @@ interface ImageGalleryProps {
 const ImageGallery: React.FC<ImageGalleryProps> = ({ images, heightClass }) => {
   return (
     <>
-      {images && images.length > 0 ? (
+      {images &&
+        images.length > 0 &&
         images.map((image, index) => (
           <div key={index} className={`col-span-1 ${heightClass}`}>
             <img
               src={`data:image/jpeg;base64,${image}`}
               crossOrigin='anonymous'
-              className='bg-gray-300 object-cover w-full h-full rounded-md'
+              className='h-full w-full rounded-md bg-gray-300 object-cover'
               alt={`Instagram image ${index + 1}`}
               style={{ objectFit: 'cover' }}
             />
           </div>
-        ))
-      ) : (
-        <div className='w-full h-full bg-gray-300'></div>
-      )}
+        ))}
     </>
   );
 };
@@ -50,65 +47,109 @@ export const InstagramWidget: React.FC<InstagramWidgetType> = ({
   switch (size) {
     case 'A':
       widgetLayout = (
-        <div className='h-full flex flex-col gap-2'>
+        <div className='flex h-full flex-col gap-2'>
           <div className='flex justify-between'>
-            <WidgetIcon type={'InstagramProfile'} className='m-0' />
+            <WidgetIcon type='InstagramProfile' className='m-0' />
           </div>
           <div>{localHeader}</div>
-          <div className='flex-grow relative overflow-hidden'>
-            <div className='grid grid-cols-3 gap-1'>
-              <ImageGallery images={content.images} heightClass='h-20' />
-              <ImageOverlay />
-            </div>
+          <div className='relative flex-grow overflow-hidden'>
+            {content.isPrivate ? (
+              <>
+                <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
+                  This account is private
+                </span>
+              </>
+            ) : content.images.length > 0 ? (
+              <div className='grid grid-cols-3 gap-1'>
+                <ImageGallery images={content.images} heightClass='h-20' />
+                <ImageOverlay />
+              </div>
+            ) : (
+              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
+                No pics posted yet!
+              </span>
+            )}
           </div>
         </div>
       );
       break;
     case 'B':
       widgetLayout = (
-        <div className='h-full flex flex-row gap-2'>
-          <div className='w-2/6 flex flex-col gap-2'>
-            <WidgetIcon type={'InstagramProfile'} className='m-0' />
+        <div className='flex h-full flex-row gap-2'>
+          <div className='flex w-2/6 flex-col gap-2'>
+            <WidgetIcon type='InstagramProfile' className='m-0' />
             <div>{localHeader}</div>
           </div>
-          <div className='w-4/6 h-full w-full relative rounded-xl overflow-hidden bg-white text-black'>
-            <div className='grid grid-cols-2 gap-2 w-full h-full'>
-              <ImageGallery images={content.images} heightClass='h-44' />
-              <ImageOverlay />
-            </div>
+          <div className='relative h-full w-full overflow-hidden rounded-xl bg-white text-black'>
+            {content.isPrivate ? (
+              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
+                This account is private
+              </span>
+            ) : content.images.length > 0 ? (
+              <div className='grid h-full w-full grid-cols-2 gap-2'>
+                <ImageGallery images={content.images} heightClass='h-44' />
+                <ImageOverlay />
+              </div>
+            ) : (
+              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
+                No pics posted yet!
+              </span>
+            )}
           </div>
         </div>
       );
       break;
     case 'C':
       widgetLayout = (
-        <div className='h-full flex flex-row gap-2'>
-          <div className='w-1/2 h-full'>
-            <div className='flex flex-col gap-1 h-full'>
-              <WidgetIcon type={'InstagramProfile'} className='m-0' />
+        <div className='flex h-full flex-row gap-2'>
+          <div className='h-full w-1/2'>
+            <div className='flex h-full flex-col gap-1'>
+              <WidgetIcon type='InstagramProfile' className='m-0' />
               <div>{localHeader}</div>
             </div>
           </div>
-          <div className='w-1/2 relative rounded-xl overflow-hidden h-full'>
-            <div className='grid grid-cols-2 gap-2 w-full h-full'>
-              <ImageGallery images={content.images} heightClass='h-20' />
-              <ImageOverlay />
-            </div>
+          <div className='relative h-full w-1/2 overflow-hidden rounded-xl'>
+            {content.isPrivate ? (
+              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
+                This account is private
+              </span>
+            ) : content.images.length > 0 ? (
+              <div className='grid h-full w-full grid-cols-2 gap-2'>
+                <ImageGallery images={content.images} heightClass='h-20' />
+                <ImageOverlay />
+              </div>
+            ) : (
+              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
+                No pics posted yet!
+              </span>
+            )}
           </div>
         </div>
       );
       break;
     case 'D':
       widgetLayout = (
-        <div className='h-full flex flex-col gap-2'>
+        <div className='flex h-full flex-col gap-2'>
           <div className='flex justify-between'>
-            <WidgetIcon type={'InstagramProfile'} className='m-0' />
+            <WidgetIcon type='InstagramProfile' className='m-0' />
           </div>
           <div>{localHeader}</div>
-          <div
-            className={`h-full w-full relative rounded-xl overflow-hidden mt-24`}
-          >
-            <div className='grid grid-cols-2 gap-2 w-full h-full'>
+          <div className='relative mt-24 h-full w-full overflow-hidden rounded-xl'>
+            {content.isPrivate ? (
+              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
+                This account is private
+              </span>
+            ) : content.images.length > 0 ? (
+              <div className='grid h-full w-full grid-cols-2 gap-2'>
+                <ImageGallery images={content.images} heightClass='h-28' />
+                <ImageOverlay />
+              </div>
+            ) : (
+              <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-200 text-sm font-semibold'>
+                No pics posted yet!
+              </span>
+            )}
+            <div className='grid h-full w-full grid-cols-2 gap-2'>
               <ImageGallery images={content.images} heightClass='h-28' />
               <ImageOverlay />
             </div>

--- a/src/components/profile/widgets/widget-link.tsx
+++ b/src/components/profile/widgets/widget-link.tsx
@@ -46,7 +46,7 @@ export const LinkWidget: React.FC<LinkWidgetProps> = ({ content, size }) => {
             <Icon src={iconUrl} />
             <Title>{title}</Title>
           </WidgetHeader>
-          <div className='flex max-h-full flex-row justify-end gap-3 overflow-hidden'>
+          <div className='flex h-full flex-row justify-end gap-3 overflow-hidden'>
             <BannerImage src={heroImageUrl} className='w-2/3 ' />
           </div>
         </WidgetLayout>

--- a/src/hooks/widgets/useGetWidgetContent.ts
+++ b/src/hooks/widgets/useGetWidgetContent.ts
@@ -22,7 +22,7 @@ export const useGetWidgetContent = () => {
       }
     },
     onError: (error) => {
-      toast({ title: 'Error', description: 'Failed to fetch widget content' });
+      toast({ title: 'Oops!', description: error.message });
     },
     // No need to invalidate query since we are not mutating data here
     // Can use onSettled callback to do something

--- a/src/hooks/widgets/useGetWidgetContent.ts
+++ b/src/hooks/widgets/useGetWidgetContent.ts
@@ -1,7 +1,8 @@
+import { useMutation } from '@tanstack/react-query';
+
 import { useToast } from '@/components/ui/use-toast';
 import { getWidgetContent } from '@/lib/service';
 import { WidgetType } from '@/types';
-import { useMutation } from '@tanstack/react-query';
 
 type GetWidgetContentParams = {
   url: string;
@@ -22,7 +23,7 @@ export const useGetWidgetContent = () => {
       }
     },
     onError: (error) => {
-      toast({ title: 'Oops!', description: error.message });
+      toast({ title: 'Something went wrong', description: error.message });
     },
     // No need to invalidate query since we are not mutating data here
     // Can use onSettled callback to do something

--- a/src/lib/service/widgets.ts
+++ b/src/lib/service/widgets.ts
@@ -316,10 +316,12 @@ export const getInstagramProfileMetadata = async ({
       withAuthHeader()
     );
     return response;
-  } catch (error: any) {
-    throw new Error(
-      `Failed to get Instagram profile metadata: ${error.response.data.message}`
-    );
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      throw new Error(error.response?.data.message);
+    } else {
+      throw new Error('Failed to get Instagram profile metadata');
+    }
   }
 };
 

--- a/src/lib/service/widgets.ts
+++ b/src/lib/service/widgets.ts
@@ -320,7 +320,7 @@ export const getInstagramProfileMetadata = async ({
     if (axios.isAxiosError(error)) {
       throw new Error(error.response?.data.message);
     } else {
-      throw new Error('Failed to get Instagram profile metadata');
+      throw new Error(`Failed to get Instagram profile metadata: ${error}`);
     }
   }
 };

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -91,6 +91,7 @@ export interface SpotifyWidgetContentType {
 export interface InstagramWidgetContentType {
   handle: string;
   images: string[];
+  isPrivate: boolean;
 }
 
 export interface SoundcloudTrackContentType {


### PR DESCRIPTION
# Description & Technical Solution
- Implements UI for private instagram accounts and instagram accounts that are valid, but haven't posted any pictures.
- Updates `handleWidgetAdd` function in `widget-container` by removing the try catch and allowing React Query to handle the error situation with the `onError` callback function.
  - Before, it was the same toast for each and every widget failure. Now, in `useGetWidgetContent.ts`, the error message that it receives is the error message that is toasted. We just need to make sure that each function that is called in `useGetWidgetContent` is throwing a descriptive message.
- Also fixes the 4x2 media being too small (simple fix from `max-h-full` to `h-full`)

# Screenshots

https://github.com/user-attachments/assets/bb2853b1-eaa3-4882-99c6-d13c80bd166a

![Screenshot 2024-09-03 at 1 57 47 AM](https://github.com/user-attachments/assets/1c9c4990-5d01-4f37-a577-a47936ca39ad)
