### PR TITLE
Adds animation on resize for share profile dialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -108,6 +108,7 @@
     "react-router-dom": "^6.18.0",
     "react-tag-autocomplete": "^7.1.0",
     "react-tag-input-component": "^2.0.2",
+    "react-use-measure": "^2.1.1",
     "recoil": "^0.7.7",
     "redux": "^4.2.1",
     "redux-devtools-extension": "^2.13.9",

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -154,7 +154,10 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
 
   return (
     <Dialog open={editModalVisible} onOpenChange={handleModalVisible}>
-      <DialogContent className='sm:rounded-[32px]' customDialogClose='hidden'>
+      <DialogContent
+        className='sm:rounded-[32px]'
+        hideDefaultCloseButton={true}
+      >
         <DialogHeader className='flex w-full flex-row items-start justify-between text-2xl font-semibold'>
           <p>Edit Profile</p>
           <X

--- a/src/components/profile/share/share-profile-dialog.tsx
+++ b/src/components/profile/share/share-profile-dialog.tsx
@@ -1,6 +1,8 @@
 'use client';
 
+import { AnimatePresence, motion } from 'framer-motion';
 import { Dispatch, SetStateAction, useState } from 'react';
+import useMeasure from 'react-use-measure';
 
 import { Dialog, DialogContent, DialogTrigger } from '@/components/ui/dialog';
 
@@ -45,6 +47,10 @@ export const ShareProfileDialog = ({
     navigator.clipboard.writeText(url);
   };
 
+  const [contentRef, { height: contentHeight }] = useMeasure();
+
+  console.log(contentHeight);
+
   return (
     <Dialog>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
@@ -53,45 +59,81 @@ export const ShareProfileDialog = ({
         customDialogClose='hidden'
         aria-describedby='Share your profile!'
       >
-        {activeView === 'ShareYourProfile' && (
-          <ShareYourProfile
-            username={username}
-            setActive={setActive}
-            handleUrlToClipboard={handleUrlToClipboard}
-          />
-        )}
-        {activeView === 'AddToSocials' && (
-          <AddToSocials setActive={setActive} />
-        )}
-        {activeView === 'ShareMyProfileTo' && (
-          <ShareMyProfileTo
-            username={username}
-            setActive={setActive}
-            handleUrlToClipboard={handleUrlToClipboard}
-          />
-        )}
-        {activeView === 'ShareOnSocials' && (
-          <ShareOnSocials
-            username={username}
-            setActive={setActive}
-            handleUrlToClipboard={handleUrlToClipboard}
-          />
-        )}
-        {activeView === 'Instagram' && (
-          <Instagram
-            username={username}
-            setActive={setActive}
-            handleUrlToClipboard={handleUrlToClipboard}
-          />
-        )}
-        {activeView === 'X' && (
-          <XTwitter
-            username={username}
-            setActive={setActive}
-            handleUrlToClipboard={handleUrlToClipboard}
-          />
-        )}
+        <motion.div
+          // TODO: address this hacky solution for the first view. For some reason, the height is not being calculated correctly when the dialog is opened.
+          animate={{
+            height: activeView === 'ShareYourProfile' ? '372px' : contentHeight,
+          }}
+          className='overflow-hidden'
+        >
+          <AnimatePresence>
+            <div ref={contentRef}>
+              {activeView === 'ShareYourProfile' && (
+                <AnimatedContainer>
+                  <ShareYourProfile
+                    username={username}
+                    setActive={setActive}
+                    handleUrlToClipboard={handleUrlToClipboard}
+                  />
+                </AnimatedContainer>
+              )}
+              {activeView === 'AddToSocials' && (
+                <AnimatedContainer>
+                  <AddToSocials setActive={setActive} />
+                </AnimatedContainer>
+              )}
+              {activeView === 'ShareMyProfileTo' && (
+                <AnimatedContainer>
+                  <ShareMyProfileTo
+                    username={username}
+                    setActive={setActive}
+                    handleUrlToClipboard={handleUrlToClipboard}
+                  />
+                </AnimatedContainer>
+              )}
+              {activeView === 'ShareOnSocials' && (
+                <AnimatedContainer>
+                  <ShareOnSocials
+                    username={username}
+                    setActive={setActive}
+                    handleUrlToClipboard={handleUrlToClipboard}
+                  />
+                </AnimatedContainer>
+              )}
+              {activeView === 'Instagram' && (
+                <AnimatedContainer>
+                  <Instagram
+                    username={username}
+                    setActive={setActive}
+                    handleUrlToClipboard={handleUrlToClipboard}
+                  />
+                </AnimatedContainer>
+              )}
+              {activeView === 'X' && (
+                <AnimatedContainer>
+                  <XTwitter
+                    username={username}
+                    setActive={setActive}
+                    handleUrlToClipboard={handleUrlToClipboard}
+                  />
+                </AnimatedContainer>
+              )}
+            </div>
+          </AnimatePresence>
+        </motion.div>
       </DialogContent>
     </Dialog>
+  );
+};
+
+const AnimatedContainer = ({ children }: { children: React.ReactNode }) => {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ delay: 0.1 }}
+    >
+      {children}
+    </motion.div>
   );
 };

--- a/src/components/profile/share/share-profile-dialog.tsx
+++ b/src/components/profile/share/share-profile-dialog.tsx
@@ -66,54 +66,54 @@ export const ShareProfileDialog = ({
         >
           <div ref={contentRef}>
             {activeView === 'ShareYourProfile' && (
-              <AnimatedContainer>
+              <FadeIn>
                 <ShareYourProfile
                   username={username}
                   setActive={setActive}
                   handleUrlToClipboard={handleUrlToClipboard}
                 />
-              </AnimatedContainer>
+              </FadeIn>
             )}
             {activeView === 'AddToSocials' && (
-              <AnimatedContainer>
+              <FadeIn>
                 <AddToSocials setActive={setActive} />
-              </AnimatedContainer>
+              </FadeIn>
             )}
             {activeView === 'ShareMyProfileTo' && (
-              <AnimatedContainer>
+              <FadeIn>
                 <ShareMyProfileTo
                   username={username}
                   setActive={setActive}
                   handleUrlToClipboard={handleUrlToClipboard}
                 />
-              </AnimatedContainer>
+              </FadeIn>
             )}
             {activeView === 'ShareOnSocials' && (
-              <AnimatedContainer>
+              <FadeIn>
                 <ShareOnSocials
                   username={username}
                   setActive={setActive}
                   handleUrlToClipboard={handleUrlToClipboard}
                 />
-              </AnimatedContainer>
+              </FadeIn>
             )}
             {activeView === 'Instagram' && (
-              <AnimatedContainer>
+              <FadeIn>
                 <Instagram
                   username={username}
                   setActive={setActive}
                   handleUrlToClipboard={handleUrlToClipboard}
                 />
-              </AnimatedContainer>
+              </FadeIn>
             )}
             {activeView === 'X' && (
-              <AnimatedContainer>
+              <FadeIn>
                 <XTwitter
                   username={username}
                   setActive={setActive}
                   handleUrlToClipboard={handleUrlToClipboard}
                 />
-              </AnimatedContainer>
+              </FadeIn>
             )}
           </div>
         </motion.div>
@@ -123,7 +123,7 @@ export const ShareProfileDialog = ({
 };
 
 /** All this does is animate the opacity of each component and adds a delay for better timing */
-const AnimatedContainer = ({ children }: { children: React.ReactNode }) => {
+const FadeIn = ({ children }: { children: React.ReactNode }) => {
   return (
     <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
       {children}

--- a/src/components/profile/share/share-profile-dialog.tsx
+++ b/src/components/profile/share/share-profile-dialog.tsx
@@ -49,10 +49,8 @@ export const ShareProfileDialog = ({
 
   const [contentRef, { height: contentHeight }] = useMeasure();
 
-  console.log(contentHeight);
-
   return (
-    <Dialog>
+    <Dialog onOpenChange={() => setActive('ShareYourProfile')}>
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent
         className='flex w-[400px] flex-col items-center gap-6 rounded-3xl bg-[#F9F7FF] p-4 sm:rounded-3xl'

--- a/src/components/profile/share/share-profile-dialog.tsx
+++ b/src/components/profile/share/share-profile-dialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AnimatePresence, motion } from 'framer-motion';
+import { motion } from 'framer-motion';
 import { Dispatch, SetStateAction, useState } from 'react';
 import useMeasure from 'react-use-measure';
 
@@ -64,66 +64,65 @@ export const ShareProfileDialog = ({
           }}
           className='overflow-hidden'
         >
-          <AnimatePresence>
-            <div ref={contentRef}>
-              {activeView === 'ShareYourProfile' && (
-                <AnimatedContainer>
-                  <ShareYourProfile
-                    username={username}
-                    setActive={setActive}
-                    handleUrlToClipboard={handleUrlToClipboard}
-                  />
-                </AnimatedContainer>
-              )}
-              {activeView === 'AddToSocials' && (
-                <AnimatedContainer>
-                  <AddToSocials setActive={setActive} />
-                </AnimatedContainer>
-              )}
-              {activeView === 'ShareMyProfileTo' && (
-                <AnimatedContainer>
-                  <ShareMyProfileTo
-                    username={username}
-                    setActive={setActive}
-                    handleUrlToClipboard={handleUrlToClipboard}
-                  />
-                </AnimatedContainer>
-              )}
-              {activeView === 'ShareOnSocials' && (
-                <AnimatedContainer>
-                  <ShareOnSocials
-                    username={username}
-                    setActive={setActive}
-                    handleUrlToClipboard={handleUrlToClipboard}
-                  />
-                </AnimatedContainer>
-              )}
-              {activeView === 'Instagram' && (
-                <AnimatedContainer>
-                  <Instagram
-                    username={username}
-                    setActive={setActive}
-                    handleUrlToClipboard={handleUrlToClipboard}
-                  />
-                </AnimatedContainer>
-              )}
-              {activeView === 'X' && (
-                <AnimatedContainer>
-                  <XTwitter
-                    username={username}
-                    setActive={setActive}
-                    handleUrlToClipboard={handleUrlToClipboard}
-                  />
-                </AnimatedContainer>
-              )}
-            </div>
-          </AnimatePresence>
+          <div ref={contentRef}>
+            {activeView === 'ShareYourProfile' && (
+              <AnimatedContainer>
+                <ShareYourProfile
+                  username={username}
+                  setActive={setActive}
+                  handleUrlToClipboard={handleUrlToClipboard}
+                />
+              </AnimatedContainer>
+            )}
+            {activeView === 'AddToSocials' && (
+              <AnimatedContainer>
+                <AddToSocials setActive={setActive} />
+              </AnimatedContainer>
+            )}
+            {activeView === 'ShareMyProfileTo' && (
+              <AnimatedContainer>
+                <ShareMyProfileTo
+                  username={username}
+                  setActive={setActive}
+                  handleUrlToClipboard={handleUrlToClipboard}
+                />
+              </AnimatedContainer>
+            )}
+            {activeView === 'ShareOnSocials' && (
+              <AnimatedContainer>
+                <ShareOnSocials
+                  username={username}
+                  setActive={setActive}
+                  handleUrlToClipboard={handleUrlToClipboard}
+                />
+              </AnimatedContainer>
+            )}
+            {activeView === 'Instagram' && (
+              <AnimatedContainer>
+                <Instagram
+                  username={username}
+                  setActive={setActive}
+                  handleUrlToClipboard={handleUrlToClipboard}
+                />
+              </AnimatedContainer>
+            )}
+            {activeView === 'X' && (
+              <AnimatedContainer>
+                <XTwitter
+                  username={username}
+                  setActive={setActive}
+                  handleUrlToClipboard={handleUrlToClipboard}
+                />
+              </AnimatedContainer>
+            )}
+          </div>
         </motion.div>
       </DialogContent>
     </Dialog>
   );
 };
 
+/** All this does is animate the opacity of each component and adds a delay for better timing */
 const AnimatedContainer = ({ children }: { children: React.ReactNode }) => {
   return (
     <motion.div

--- a/src/components/profile/share/share-profile-dialog.tsx
+++ b/src/components/profile/share/share-profile-dialog.tsx
@@ -125,11 +125,7 @@ export const ShareProfileDialog = ({
 /** All this does is animate the opacity of each component and adds a delay for better timing */
 const AnimatedContainer = ({ children }: { children: React.ReactNode }) => {
   return (
-    <motion.div
-      initial={{ opacity: 0 }}
-      animate={{ opacity: 1 }}
-      transition={{ delay: 0.1 }}
-    >
+    <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }}>
       {children}
     </motion.div>
   );

--- a/src/components/profile/share/share-profile-dialog.tsx
+++ b/src/components/profile/share/share-profile-dialog.tsx
@@ -54,7 +54,7 @@ export const ShareProfileDialog = ({
       <DialogTrigger asChild>{trigger}</DialogTrigger>
       <DialogContent
         className='flex w-[400px] flex-col items-center gap-6 rounded-3xl bg-[#F9F7FF] p-4 sm:rounded-3xl'
-        customDialogClose='hidden'
+        hideDefaultCloseButton={true}
         aria-describedby='Share your profile!'
       >
         <motion.div

--- a/src/components/profile/share/views/share-your-profile.tsx
+++ b/src/components/profile/share/views/share-your-profile.tsx
@@ -1,5 +1,4 @@
 import { Plus, Send01, Share01 } from '@untitled-ui/icons-react';
-import { motion } from 'framer-motion';
 
 import { Button } from '@/components/ui/button';
 
@@ -14,7 +13,7 @@ export const ShareYourProfile = ({
   handleUrlToClipboard,
 }: ShareYourProfileProps) => {
   return (
-    <motion.div>
+    <>
       <Header
         title='Share your profile'
         description='Showcase your skills globally - share your Sorbet profile on all your channels.'
@@ -47,6 +46,6 @@ export const ShareYourProfile = ({
           />
         </Button>
       </Body>
-    </motion.div>
+    </>
   );
 };

--- a/src/components/profile/share/views/share-your-profile.tsx
+++ b/src/components/profile/share/views/share-your-profile.tsx
@@ -1,4 +1,5 @@
 import { Plus, Send01, Share01 } from '@untitled-ui/icons-react';
+import { motion } from 'framer-motion';
 
 import { Button } from '@/components/ui/button';
 
@@ -13,7 +14,7 @@ export const ShareYourProfile = ({
   handleUrlToClipboard,
 }: ShareYourProfileProps) => {
   return (
-    <>
+    <motion.div>
       <Header
         title='Share your profile'
         description='Showcase your skills globally - share your Sorbet profile on all your channels.'
@@ -46,6 +47,6 @@ export const ShareYourProfile = ({
           />
         </Button>
       </Body>
-    </>
+    </motion.div>
   );
 };

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -30,14 +30,14 @@ const DialogOverlay = React.forwardRef<
 DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
 
 interface DialogContentProps extends React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content> {
-  customDialogClose?: string;
+  hideDefaultCloseButton?: boolean;
 }
 
 const DialogContent = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Content>,
   DialogContentProps
 >(({ className, children, ...props }, ref) => {
-  const {customDialogClose} = props
+  const {hideDefaultCloseButton} = props
  
   return (
 
@@ -52,7 +52,7 @@ const DialogContent = React.forwardRef<
       {...props}
     >
       {children}
-      <DialogPrimitive.Close className={cn("absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground", customDialogClose)}>
+      <DialogPrimitive.Close className={cn("absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground", hideDefaultCloseButton && 'hidden')}>
         <X className="h-4 w-4" />
         <span className="sr-only">Close</span>
       </DialogPrimitive.Close>

--- a/yarn.lock
+++ b/yarn.lock
@@ -9262,6 +9262,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debounce@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "debounce@npm:1.2.1"
+  checksum: 10c0/6c9320aa0973fc42050814621a7a8a78146c1975799b5b3cc1becf1f77ba9a5aa583987884230da0842a03f385def452fad5d60db97c3d1c8b824e38a8edf500
+  languageName: node
+  linkType: hard
+
 "debug@npm:4, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.4, debug@npm:~4.3.1, debug@npm:~4.3.2":
   version: 4.3.5
   resolution: "debug@npm:4.3.5"
@@ -15454,6 +15461,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-use-measure@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "react-use-measure@npm:2.1.1"
+  dependencies:
+    debounce: "npm:^1.2.1"
+  peerDependencies:
+    react: ">=16.13"
+    react-dom: ">=16.13"
+  checksum: 10c0/77b035189dbd613f50014ae56cbfc1363a4eba5104f68f3bc09cbdd20719ae7fb42884e53328175c30b238215c5b8064c60098d70b3fa9b8d902db6ffb07c6a3
+  languageName: node
+  linkType: hard
+
 "react@npm:^18.2.0":
   version: 18.3.1
   resolution: "react@npm:18.3.1"
@@ -16446,6 +16465,7 @@ __metadata:
     react-router-dom: "npm:^6.18.0"
     react-tag-autocomplete: "npm:^7.1.0"
     react-tag-input-component: "npm:^2.0.2"
+    react-use-measure: "npm:^2.1.1"
     recoil: "npm:^0.7.7"
     redux: "npm:^4.2.1"
     redux-devtools-extension: "npm:^2.13.9"


### PR DESCRIPTION
# Description & Technical Solution
- Adds `react-use-measure` package that calculates height of a component
- Implements framer motion to animate height changes
- Changes `customDialogClose: string` prop to `hideDefaultCloseButton: boolean` in shadcn `dialog` component for better readability.

** Opted not to add the horizontal animations because I felt that it would be too much and very distracting. Felt that opacity and height resize animation is clean and sleek. Open to discussion tho!

If it were something like this: https://ui.lukacho.com/components/dropdown-menu where a user has a sense of direction because everything is displayed, then i think a horizontal slide makes sense. I digress, but these are just my thoughts.

# Screenshots

https://github.com/user-attachments/assets/3d3b3ebc-c809-4345-9753-ae5910eb8a60

