### PR TITLE
SRBT-148 Adds proper disabled state for save button in profile edit modal

### DIFF
--- a/src/components/onboarding/signup/step1.tsx
+++ b/src/components/onboarding/signup/step1.tsx
@@ -62,7 +62,7 @@ const Step1 = () => {
     mode: 'all',
   });
 
-  const { errors, isDirty, dirtyFields, isValid } = useFormState({
+  const { errors, dirtyFields, isValid } = useFormState({
     control: form.control,
   });
 

--- a/src/components/onboarding/signup/step1.tsx
+++ b/src/components/onboarding/signup/step1.tsx
@@ -62,7 +62,7 @@ const Step1 = () => {
     mode: 'all',
   });
 
-  const { errors, dirtyFields, isValid } = useFormState({
+  const { errors, isValid } = useFormState({
     control: form.control,
   });
 
@@ -231,7 +231,7 @@ const Step1 = () => {
             <Button
               type='submit'
               className='w-full border-[#7F56D9] bg-[#573DF5] text-[#FFFFFF] shadow-sm shadow-[#1018280D]'
-              disabled={!isValid || Object.keys(dirtyFields).length <= 0}
+              disabled={!isValid}
             >
               Next
             </Button>

--- a/src/components/onboarding/signup/step1.tsx
+++ b/src/components/onboarding/signup/step1.tsx
@@ -62,7 +62,7 @@ const Step1 = () => {
     mode: 'all',
   });
 
-  const { errors, isDirty } = useFormState({
+  const { errors, isDirty, dirtyFields, isValid } = useFormState({
     control: form.control,
   });
 
@@ -231,7 +231,7 @@ const Step1 = () => {
             <Button
               type='submit'
               className='w-full border-[#7F56D9] bg-[#573DF5] text-[#FFFFFF] shadow-sm shadow-[#1018280D]'
-              disabled={Object.keys(errors).length > 0 || !isDirty}
+              disabled={!isValid || Object.keys(dirtyFields).length <= 0}
             >
               Next
             </Button>

--- a/src/components/profile/location-input.tsx
+++ b/src/components/profile/location-input.tsx
@@ -41,7 +41,6 @@ export const LocationInput = <T extends FieldValues>({
             onChange={(e) => {
               setValue(name, e.target.value as PathValue<T, Path<T>>, {
                 shouldDirty: true,
-                shouldTouch: true,
               });
               handleLocationInputChange(e);
             }}

--- a/src/components/profile/location-input.tsx
+++ b/src/components/profile/location-input.tsx
@@ -38,7 +38,13 @@ export const LocationInput = <T extends FieldValues>({
             {...register(name, {
               required: 'Location is required',
             })}
-            onChange={(e) => handleLocationInputChange(e)}
+            onChange={(e) => {
+              setValue(name, e.target.value as PathValue<T, Path<T>>, {
+                shouldDirty: true,
+                shouldTouch: true,
+              });
+              handleLocationInputChange(e);
+            }}
             autoComplete='off'
             className='pl-10 focus:outline-none focus:ring-0'
           />
@@ -93,7 +99,10 @@ const LocationPredictionsList = <T extends FieldValues>({
           key={prediction.place_id}
           value={prediction.description}
           onSelect={() => {
-            setValue(name, prediction.description as PathValue<T, Path<T>>);
+            setValue(name, prediction.description as PathValue<T, Path<T>>, {
+              shouldDirty: true,
+              shouldTouch: true,
+            });
             setPredictions([]);
           }}
           className=' text-black'

--- a/src/components/profile/location-input.tsx
+++ b/src/components/profile/location-input.tsx
@@ -100,7 +100,6 @@ const LocationPredictionsList = <T extends FieldValues>({
           onSelect={() => {
             setValue(name, prediction.description as PathValue<T, Path<T>>, {
               shouldDirty: true,
-              shouldTouch: true,
             });
             setPredictions([]);
           }}

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -141,7 +141,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
     );
     const i = e.target.files[0];
     setImage(URL.createObjectURL(i));
-    setValue('isImageUpdated', true, { shouldDirty: true, shouldTouch: true });
+    setValue('isImageUpdated', true, { shouldDirty: true });
   };
 
   const deleteImage = async (e: React.MouseEvent<HTMLDivElement>) => {
@@ -152,13 +152,10 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
     // If there is no image and we supply one, but then delete, we are considering it clean
     setValue('isImageUpdated', isImageUpdated ? false : true, {
       shouldDirty: true,
-      shouldTouch: true,
     });
 
     setImage(undefined);
     setFile(undefined);
-
-    // setValue('isImageUpdated', false, { shouldDirty: true, shouldTouch: true });
 
     const fileInput = document.getElementById(
       'profileImage'
@@ -170,8 +167,6 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
 
   const handleSkillChange = (newSkills: string[]) => {
     setValue('tags', newSkills, {
-      shouldValidate: true,
-      shouldTouch: true,
       shouldDirty: true,
     });
   };

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -3,7 +3,7 @@ import { useQueryClient } from '@tanstack/react-query';
 import { User01, X } from '@untitled-ui/icons-react';
 import { Loader2 } from 'lucide-react';
 import { ChangeEvent, useState } from 'react';
-import { Controller } from 'react-hook-form';
+import { Controller, useFormState } from 'react-hook-form';
 import { useForm } from 'react-hook-form';
 import { z } from 'zod';
 
@@ -11,7 +11,12 @@ import { LocationInput } from '@/components/profile';
 import SkillInput from '@/components/syntax-ui/skill-input';
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogHeader } from '@/components/ui/dialog';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import {
   useDeleteProfileImage,
@@ -67,6 +72,11 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
       tags: user?.tags,
     },
   });
+
+  const { dirtyFields, defaultValues } = useFormState({ control });
+
+  console.log(dirtyFields);
+  console.log(Object.keys(dirtyFields).length);
 
   const {
     isPending: uploadProfileImagePending,
@@ -162,14 +172,17 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
       <DialogContent
         className='sm:rounded-[32px]'
         hideDefaultCloseButton={true}
+        aria-describedby={undefined}
       >
-        <DialogHeader className='flex w-full flex-row items-start justify-between text-2xl font-semibold'>
-          <p>Edit Profile</p>
-          <X
-            className='h-6 w-6 cursor-pointer text-[#98A2B3] transition ease-out hover:scale-110'
-            onClick={() => handleModalVisible(false)}
-          />
-        </DialogHeader>
+        <DialogTitle>
+          <DialogHeader className='flex w-full flex-row items-start justify-between text-2xl font-semibold'>
+            <p>Edit Profile</p>
+            <X
+              className='h-6 w-6 cursor-pointer text-[#98A2B3] transition ease-out hover:scale-110'
+              onClick={() => handleModalVisible(false)}
+            />
+          </DialogHeader>
+        </DialogTitle>
         <div className='flex flex-col gap-6'>
           <div className='flex items-center gap-2 text-[#344054]'>
             <Avatar className='border-primary-default h-20 w-20 border-2'>
@@ -311,7 +324,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
                 <Button
                   type='submit'
                   className='bg-sorbet w-full'
-                  disabled={loading}
+                  disabled={loading || Object.keys(dirtyFields).length <= 0}
                 >
                   {loading ? (
                     <>

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -173,7 +173,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
     deleteProfileImagePending ||
     uploadProfileImagePending;
 
-  // This effect is to make sure that the form is updated with all the newest changes
+  // This effect is to make sure that the form is updated with all the newest changes or restore default values
   useEffect(() => {
     if (!isSubmitSuccessful) {
       reset();
@@ -330,10 +330,10 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
                   control={control}
                   render={() => (
                     <SkillInput
-                      {...register('tags')}
                       initialSkills={user?.tags || []}
-                      unique
                       onSkillsChange={handleSkillChange}
+                      unique
+                      {...register('tags')}
                     />
                   )}
                 />

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -74,9 +74,6 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
 
   const { dirtyFields } = useFormState({ control });
 
-  console.log(dirtyFields);
-  console.log(Object.keys(dirtyFields).length);
-
   const {
     isPending: uploadProfileImagePending,
     mutateAsync: uploadProfileImageAsync,

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -47,7 +47,9 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
   handleModalVisible,
   user,
 }) => {
-  const [image, setImage] = useState<string | undefined>();
+  const [image, setImage] = useState<string | undefined>(
+    user?.profileImage || undefined
+  );
   const [file, setFile] = useState<Blob | undefined>(undefined);
 
   const queryClient = useQueryClient();
@@ -137,6 +139,8 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
         : undefined
     );
     const i = e.target.files[0];
+    // TODO: eventually consolidate these two calls since they are called together in multiple places
+    // Can be as simple as changing the 'isImageUpdated' property in zod schema from boolean to the string value of 'image'
     setImage(URL.createObjectURL(i));
     setValue('isImageUpdated', true, { shouldDirty: true });
   };

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -63,7 +63,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
   } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: {
-      isImageUpdated: false,
+      isImageUpdated: false, // --> since image is not controlled by form, this allows us to stay within RHF for disabling the 'Save Changes' button.
       firstName: user?.firstName,
       lastName: user?.lastName,
       bio: user?.bio,

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -159,7 +159,11 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
   };
 
   const handleSkillChange = (newSkills: string[]) => {
-    setValue('tags', newSkills);
+    setValue('tags', newSkills, {
+      shouldValidate: true,
+      shouldTouch: true,
+      shouldDirty: true,
+    });
   };
 
   const loading =
@@ -305,14 +309,19 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
                   {...register('tags')}
                   name='tags'
                   control={control}
-                  render={() => (
-                    <SkillInput
-                      initialSkills={user?.tags || []}
-                      onSkillsChange={handleSkillChange}
-                      unique
-                      {...register('tags')}
-                    />
-                  )}
+                  render={() => {
+                    const { onChange, onBlur, name, ref } = register('tags');
+
+                    return (
+                      <SkillInput
+                        ref={ref}
+                        onChange={onChange}
+                        initialSkills={user?.tags || []}
+                        unique
+                        onSkillsChange={handleSkillChange}
+                      />
+                    );
+                  }}
                 />
                 {errors.tags && (
                   <p className='mt-1 text-xs text-red-500'>

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -26,6 +26,7 @@ import {
 import type { User } from '@/types';
 
 const schema = z.object({
+  isImageUpdated: z.boolean(),
   firstName: z.string().min(1, 'First name is required'),
   lastName: z.string().min(1, 'Last name is required'),
   bio: z.string().max(100, 'Bio must be at most 100 characters'),
@@ -64,6 +65,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
   } = useForm<FormData>({
     resolver: zodResolver(schema),
     defaultValues: {
+      isImageUpdated: false,
       firstName: user?.firstName,
       lastName: user?.lastName,
       bio: user?.bio,
@@ -141,6 +143,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
     );
     const i = e.target.files[0];
     setImage(URL.createObjectURL(i));
+    setValue('isImageUpdated', true, { shouldDirty: true, shouldTouch: true });
   };
 
   const deleteImage = async (e: React.MouseEvent<HTMLDivElement>) => {
@@ -155,6 +158,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
     if (fileInput) {
       fileInput.value = '';
     }
+    setValue('isImageUpdated', false, { shouldDirty: true, shouldTouch: true });
   };
 
   const handleSkillChange = (newSkills: string[]) => {
@@ -173,7 +177,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
   // This effect is to make sure that the form is updated with all the newest changes
   useEffect(() => {
     const values = getValues();
-    reset({ ...values });
+    reset({ ...values, isImageUpdated: false });
   }, [isSubmitSuccessful, reset, getValues]);
 
   return (

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -151,7 +151,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
     const isImageUpdated = getValues('isImageUpdated');
     // If there is a pre-existing image and we delete, we are considering it dirty
     // If there is no image and we supply one, but then delete, we are considering it clean
-    setValue('isImageUpdated', isImageUpdated ? false : true, {
+    setValue('isImageUpdated', !isImageUpdated, {
       shouldDirty: true,
     });
 

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -72,7 +72,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
     },
   });
 
-  const { dirtyFields } = useFormState({ control });
+  const { isDirty } = useFormState({ control });
 
   const {
     isPending: uploadProfileImagePending,
@@ -347,7 +347,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
                 <Button
                   type='submit'
                   className='bg-sorbet w-full'
-                  disabled={loading || Object.keys(dirtyFields).length <= 0}
+                  disabled={loading || !isDirty}
                 >
                   {loading ? (
                     <>

--- a/src/components/profile/profile-edit-modal.tsx
+++ b/src/components/profile/profile-edit-modal.tsx
@@ -47,9 +47,7 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
   handleModalVisible,
   user,
 }) => {
-  const [image, setImage] = useState<string | undefined>(
-    user?.profileImage || undefined
-  );
+  const [image, setImage] = useState<string | undefined>();
   const [file, setFile] = useState<Blob | undefined>(undefined);
 
   const queryClient = useQueryClient();
@@ -149,8 +147,18 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
   const deleteImage = async (e: React.MouseEvent<HTMLDivElement>) => {
     e.preventDefault();
 
+    const isImageUpdated = getValues('isImageUpdated');
+    // If there is a pre-existing image and we delete, we are considering it dirty
+    // If there is no image and we supply one, but then delete, we are considering it clean
+    setValue('isImageUpdated', isImageUpdated ? false : true, {
+      shouldDirty: true,
+      shouldTouch: true,
+    });
+
     setImage(undefined);
     setFile(undefined);
+
+    // setValue('isImageUpdated', false, { shouldDirty: true, shouldTouch: true });
 
     const fileInput = document.getElementById(
       'profileImage'
@@ -158,7 +166,6 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
     if (fileInput) {
       fileInput.value = '';
     }
-    setValue('isImageUpdated', false, { shouldDirty: true, shouldTouch: true });
   };
 
   const handleSkillChange = (newSkills: string[]) => {
@@ -176,9 +183,20 @@ export const ProfileEditModal: React.FC<ProfileEditModalProps> = ({
 
   // This effect is to make sure that the form is updated with all the newest changes
   useEffect(() => {
+    if (!isSubmitSuccessful) {
+      reset();
+      setImage(user?.profileImage || undefined);
+      return;
+    }
     const values = getValues();
     reset({ ...values, isImageUpdated: false });
-  }, [isSubmitSuccessful, reset, getValues]);
+  }, [
+    isSubmitSuccessful,
+    reset,
+    getValues,
+    editModalVisible,
+    user?.profileImage,
+  ]);
 
   return (
     <Dialog open={editModalVisible} onOpenChange={handleModalVisible}>

--- a/src/components/syntax-ui/skill-input.tsx
+++ b/src/components/syntax-ui/skill-input.tsx
@@ -1,12 +1,12 @@
 import { SearchLg } from '@untitled-ui/icons-react';
 import { AnimatePresence, motion, useAnimate } from 'framer-motion';
-import { MouseEvent, useState } from 'react';
+import { ComponentProps, MouseEvent, useState } from 'react';
 
 import { SkillBadge } from '@/components/onboarding/signup/skill-badge';
 
 const MaxNumOfSkills = 5;
 
-interface SkillInputProps {
+interface SkillInputProps extends ComponentProps<'input'> {
   initialSkills: string[];
   onSkillsChange: (skill: string[]) => void;
   unique: boolean;
@@ -23,6 +23,7 @@ const SkillInput = ({
   initialSkills,
   onSkillsChange,
   unique = false,
+  ...props
 }: SkillInputProps) => {
   const [skills, setSkills] = useState<string[]>(initialSkills);
   const [inputValue, setInputValue] = useState<string>('');
@@ -137,6 +138,7 @@ const SkillInput = ({
             ))}
           </AnimatePresence>
           <input
+            {...props}
             type='text'
             value={inputValue}
             onChange={handleChange}


### PR DESCRIPTION
# Description & Technical Solution
- Disables `save` button when a user has not made any changes
    - For `location-input` and `skill-input` and profile image, this is done through the `setValue` function by passing `shouldDirty` as the options argument.
- Adds `isImageUpdated` property to zod schema so that we can easily check if the image field is dirty through React Hook Form. (The image is not controlled by RHF, but rather local state instead.)
- Implements an effect to reset the form and update default values only when the form has been successfully submitted.
    - Form wasn't syncing to latest changes on save


** Also fixes step1, only disabling continue button on first render (no dirty fields), and when required fields are filled out (`isValid`)

# Video

https://github.com/user-attachments/assets/10af48da-5ba3-495c-ac53-18729c3407b2

