### PR TITLE
Update notifications with redirect functionality

### DIFF
--- a/src/components/notifications/notification-toasts.tsx
+++ b/src/components/notifications/notification-toasts.tsx
@@ -1,6 +1,7 @@
-import { useToast } from '@/components/ui/use-toast';
 import { useKnockFeed } from '@knocklabs/react';
-import { ReactNode, useCallback, useEffect } from 'react';
+import { useCallback, useEffect } from 'react';
+
+import { useToast } from '@/components/ui/use-toast';
 
 const NotificationToasts = () => {
   const { feedClient } = useKnockFeed();

--- a/src/components/notifications/notifications.tsx
+++ b/src/components/notifications/notifications.tsx
@@ -6,6 +6,7 @@ import {
   NotificationFeedPopover,
   NotificationIconButton,
 } from '@knocklabs/react';
+import { useRouter } from 'next/navigation';
 import React, { useRef, useState } from 'react';
 
 import { NotificationToasts } from '@/components/notifications';
@@ -16,6 +17,7 @@ export const Notifications = () => {
   const [isVisible, setIsVisible] = useState(false);
   const buttonRef = useRef(null);
   const { user } = useAuth();
+  const router = useRouter();
 
   // No user, no notifications
   if (!user) {
@@ -37,6 +39,15 @@ export const Notifications = () => {
             buttonRef={buttonRef}
             isVisible={isVisible}
             onClose={() => setIsVisible(false)}
+            // TODO: Redirect to appropriate route based on 'item' data.
+            // TODO: The identifier would come from the backend, ideally relating to how we put state in the url
+            // TODO: i.e: if we put contract id in the url, the backend would populate the 'data' prop with the contract id
+            // For now, it is a simple redirect to 'gigs' page. As we have that more solidified, we can then have more detailed/specific redirects
+            onNotificationClick={(item) => {
+              console.log('item from onNotificationClick', item.data);
+              // TODO: look into why this works bc this isn't a client component at the moment
+              router.push('/gigs');
+            }}
           />
           <NotificationToasts />
         </KnockFeedProvider>

--- a/src/components/notifications/notifications.tsx
+++ b/src/components/notifications/notifications.tsx
@@ -39,8 +39,8 @@ export const Notifications = () => {
             buttonRef={buttonRef}
             isVisible={isVisible}
             onClose={() => setIsVisible(false)}
-            // TODO: Redirect to appropriate route based on 'item' data.
-            // TODO: The identifier would come from the backend, ideally relating to how we put state in the url
+            // TODO: Redirect to appropriate route based on 'item' data that comes from Knock
+            // TODO: The identifier would come from the backend where we call Knock, ideally relating to how we put state in the url
             // TODO: i.e: if we put contract id in the url, the backend would populate the 'data' prop with the contract id
             // For now, it is a simple redirect to 'gigs' page. As we have that more solidified, we can then have more detailed/specific redirects
             onNotificationClick={(item) => {

--- a/src/components/notifications/notifications.tsx
+++ b/src/components/notifications/notifications.tsx
@@ -44,7 +44,7 @@ export const Notifications = () => {
             // TODO: i.e: if we put contract id in the url, the backend would populate the 'data' prop with the contract id
             // For now, it is a simple redirect to 'gigs' page. As we have that more solidified, we can then have more detailed/specific redirects
             onNotificationClick={(item) => {
-              console.log('item from onNotificationClick', item.data);
+              console.log('onNotificationClick: ', item.data);
               // TODO: look into why this works bc this isn't a client component at the moment
               router.push('/gigs');
             }}

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -111,7 +111,11 @@ const ToastDescription = React.forwardRef<
 ));
 ToastDescription.displayName = ToastPrimitives.Description.displayName;
 
-/** This type is straight from shadcn, except for the href */
+/** 
+ * This type is straight from shadcn, except for the href.
+ * href: is a property when you call the 'toast' function from useToast. 
+ * The value is where the Link is redirecting, so ensure that the path is correct.
+*/
 type ToastProps = React.ComponentPropsWithoutRef<typeof Toast> & {
   href?: string
 };

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -111,7 +111,9 @@ const ToastDescription = React.forwardRef<
 ));
 ToastDescription.displayName = ToastPrimitives.Description.displayName;
 
-type ToastProps = React.ComponentPropsWithoutRef<typeof Toast>;
+type ToastProps = React.ComponentPropsWithoutRef<typeof Toast> & {
+  href?: string
+};
 
 type ToastActionElement = React.ReactElement<typeof ToastAction>;
 

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -111,6 +111,7 @@ const ToastDescription = React.forwardRef<
 ));
 ToastDescription.displayName = ToastPrimitives.Description.displayName;
 
+/** This type is straight from shadcn, except for the href */
 type ToastProps = React.ComponentPropsWithoutRef<typeof Toast> & {
   href?: string
 };

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -15,10 +15,10 @@ export function Toaster() {
 
   return (
     <ToastProvider>
-      {toasts.map(function ({ id, title, description, action, ...props }) {
+      {toasts.map(function ({ id, title, description, action, href, ...props }) {
         return (
           <Toast key={id} {...props}>
-              <a href="/gigs">
+              <a href={href ?? '/gigs'}>
                 <div className="grid gap-1">
                   {title && <ToastTitle>{title}</ToastTitle>}
                   {description && (

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -9,6 +9,7 @@ import {
   ToastViewport,
 } from "@/components/ui/toast"
 import { useToast } from "@/components/ui/use-toast"
+import Link from "next/link"
 
 export function Toaster() {
   const { toasts } = useToast()
@@ -18,7 +19,7 @@ export function Toaster() {
       {toasts.map(function ({ id, title, description, action, href, ...props }) {
         return (
           <Toast key={id} {...props}>
-              <a href={href ?? '/gigs'}>
+              <Link href={href ?? '/gigs'} className="grid gap-1">
                 <div className="grid gap-1">
                   {title && <ToastTitle>{title}</ToastTitle>}
                   {description && (
@@ -26,7 +27,7 @@ export function Toaster() {
                   )}
                 </div>
                 {action}
-              </a>
+              </Link>
             <ToastClose />
           </Toast>
         )

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -18,13 +18,15 @@ export function Toaster() {
       {toasts.map(function ({ id, title, description, action, ...props }) {
         return (
           <Toast key={id} {...props}>
-            <div className="grid gap-1">
-              {title && <ToastTitle>{title}</ToastTitle>}
-              {description && (
-                <ToastDescription>{description}</ToastDescription>
-              )}
-            </div>
-            {action}
+              <a href="/gigs">
+                <div className="grid gap-1">
+                  {title && <ToastTitle>{title}</ToastTitle>}
+                  {description && (
+                    <ToastDescription>{description}</ToastDescription>
+                  )}
+                </div>
+                {action}
+              </a>
             <ToastClose />
           </Toast>
         )


### PR DESCRIPTION
# [SRBT-193] Update notifications with redirect functionality

**Changes**

- Implements redirect functionality for Knock feed and toast when items are clicked
- Adds `href` property to `ToastProps` in `toast.tsx`
- Adds `a` tag wrapping the toast content in `toaster.tsx`
- Adds `onNotificationClick` callback to trigger a redirect to `/gigs` for now

- Note:
  - State still needs to be raised to url for select routes, just waiting on the development of that as there may be changes to gigs.
