### PR TITLE
Fix layout shift

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -37,7 +37,8 @@ export default function RootLayout({
   children: React.ReactNode;
 }) {
   return (
-    <html className={cn('size-full', inter.className)}>
+    // classnames prevent horizontal layout shift when radix models open
+    <html className={cn('h-full w-screen overflow-x-hidden', inter.className)}>
       <body className='size-full bg-[#F2F3F7]'>
         <ClientProviders>{children}</ClientProviders>
       </body>

--- a/src/components/profile/widgets/widget-grid.tsx
+++ b/src/components/profile/widgets/widget-grid.tsx
@@ -494,7 +494,7 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
         </ReactGridLayout>
 
         {editMode && (
-          <div className='fixed bottom-0 left-1/2 z-30 -translate-x-1/2 -translate-y-6 transform'>
+          <div className='fix-modal-layout-shift fixed bottom-0 left-1/2 z-30 -translate-x-1/2 -translate-y-6 transform'>
             <AddWidgets addUrl={handleWidgetAdd} loading={addingWidget} />
           </div>
         )}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -80,6 +80,7 @@
 
   /* Prevents a horizontal layout shift (for fixed elements) when radix modals are open */
   /* Use this on your fixed positioned elements that are affected by the shift */
+  /* See https://github.com/radix-ui/primitives/discussions/1586#discussioncomment-6641424 */
   .fix-modal-layout-shift {
     padding-right: var(--removed-body-scroll-bar-size);
   }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -75,3 +75,12 @@
     @apply bg-background text-foreground;
   }
 }
+
+@layer utilities {
+
+  /* Prevents a horizontal layout shift (for fixed elements) when radix modals are open */
+  /* Use this on your fixed positioned elements that are affected by the shift */
+  .fix-modal-layout-shift {
+    padding-right: var(--removed-body-scroll-bar-size);
+  }
+}


### PR DESCRIPTION
# Fix layout shift

By hiding horizontal scroll on `html` and adding a `fix-modal-layout-shift` utility for special cases