### PR TITLE
[SRBT-263] fix(invalid-alert): added an external link to sorbet documentation

### DIFF
--- a/src/components/profile/widgets/invalid-alert.tsx
+++ b/src/components/profile/widgets/invalid-alert.tsx
@@ -33,7 +33,7 @@ export const InvalidAlert: React.FC<InvalidAlertProps> = ({
             Dismiss
           </div>
           <a
-            href='https://docs.mysorbet.xyz/sorbet'
+            href='https://docs.mysorbet.xyz/sorbet/key-features/quickstart/list-of-supported-widgets'
             target='_blank'
             rel='noopener noreferrer'
             className='text-sorbet font-semibold hover:underline'

--- a/src/components/profile/widgets/invalid-alert.tsx
+++ b/src/components/profile/widgets/invalid-alert.tsx
@@ -1,4 +1,5 @@
 import { CircleAlert, X } from 'lucide-react';
+import Link from 'next/link';
 import React, { ReactNode } from 'react';
 
 interface InvalidAlertProps {
@@ -31,9 +32,14 @@ export const InvalidAlert: React.FC<InvalidAlertProps> = ({
           >
             Dismiss
           </div>
-          <div className='text-sorbet font-semibold hover:underline'>
+          <a
+            href='https://docs.mysorbet.xyz/sorbet'
+            target='_blank'
+            rel='noopener noreferrer'
+            className='text-sorbet font-semibold hover:underline'
+          >
             Learn More
-          </div>
+          </a>
         </div>
       </div>
       <div className='align-center flex justify-center'>


### PR DESCRIPTION
# [SRBT-263] External Links to Sorbet Documentation

**Changes**

- Clicking on the "Learn More" button when an invalid alert appear redirects users to the documentation.
