### PR TITLE
[SRBT-330] Adjusted wallet container width + added wallet truncation

### DIFF
--- a/src/app/wallet/all/transactions-table.tsx
+++ b/src/app/wallet/all/transactions-table.tsx
@@ -6,7 +6,11 @@ import { DateRange } from 'react-day-picker';
 import { Spinner } from '@/components/common';
 import { DatePickerWithRange } from '@/components/ui/date-range-picker';
 import { env } from '@/lib/env';
-import { formatWalletAddress } from '@/app/wallet/utils';
+import {
+  formatCurrency,
+  formatTransactionDate,
+  formatWalletAddress,
+} from '@/app/wallet/utils';
 
 export interface TableTransaction {
   account: string;
@@ -143,7 +147,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
                 </td>
                 <td className='w-1/5 whitespace-nowrap py-4'>
                   <div className='text-sm font-medium text-gray-900'>
-                    {transaction.date.split(',')[0]}
+                    {formatTransactionDate(transaction.date)}
                   </div>
                 </td>
                 <td
@@ -153,7 +157,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
                   <div className='flex items-center justify-end gap-2'>
                     <div className='text-sm font-medium'>
                       {transaction.type === 'Sent' ? '-' : '+'}{' '}
-                      {Number(transaction.amount).toLocaleString()} USDC
+                      {formatCurrency(transaction.amount)} USDC
                     </div>
                     <LinkExternal02 width={18} height={18} color='#595B5A' />
                   </div>

--- a/src/app/wallet/all/transactions-table.tsx
+++ b/src/app/wallet/all/transactions-table.tsx
@@ -40,6 +40,10 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
     window.open(`${env.NEXT_PUBLIC_BASE_EXPLORER}/tx/${hash}`, '_blank');
   };
 
+  const truncateAccount = (account: string) => {
+    return `${account.slice(0, 5)}...${account.slice(-5)}`;
+  };
+
   return (
     <div className='relative min-h-[100%] rounded-xl bg-white p-6 shadow-[0px_10px_30px_0px_#00000014]'>
       {isLoading && (
@@ -130,7 +134,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
                     </div>
                     <div className='ml-4'>
                       <div className='text-sm font-medium text-gray-900'>
-                        {transaction.account}
+                        {truncateAccount(transaction.account)}
                       </div>
                       <div className='mt-1 text-xs text-[#595B5A]'>
                         {transaction.type === 'Self-transfer'

--- a/src/app/wallet/all/transactions-table.tsx
+++ b/src/app/wallet/all/transactions-table.tsx
@@ -6,6 +6,7 @@ import { DateRange } from 'react-day-picker';
 import { Spinner } from '@/components/common';
 import { DatePickerWithRange } from '@/components/ui/date-range-picker';
 import { env } from '@/lib/env';
+import { formatWalletAddress } from '@/app/wallet/utils';
 
 export interface TableTransaction {
   account: string;
@@ -38,10 +39,6 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
 }) => {
   const handleTxnClick = (hash: string) => {
     window.open(`${env.NEXT_PUBLIC_BASE_EXPLORER}/tx/${hash}`, '_blank');
-  };
-
-  const truncateAccount = (account: string) => {
-    return `${account.slice(0, 5)}...${account.slice(-5)}`;
   };
 
   return (
@@ -134,7 +131,7 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
                     </div>
                     <div className='ml-4'>
                       <div className='text-sm font-medium text-gray-900'>
-                        {truncateAccount(transaction.account)}
+                        {formatWalletAddress(transaction.account)}
                       </div>
                       <div className='mt-1 text-xs text-[#595B5A]'>
                         {transaction.type === 'Self-transfer'

--- a/src/app/wallet/funds-flow.tsx
+++ b/src/app/wallet/funds-flow.tsx
@@ -22,6 +22,7 @@ const BalanceItem: React.FC<BalanceItemProps> = ({
   account,
   balance,
 }) => {
+  const truncatedAccount = `${account.slice(0, 5)}...${account.slice(-5)}`;
   return (
     <div className='flex items-center justify-between'>
       <div className='flex items-center gap-3'>
@@ -29,7 +30,7 @@ const BalanceItem: React.FC<BalanceItemProps> = ({
           {icon}
         </span>
         <div className='flex flex-col'>
-          <span className='text-sm font-medium'>{account}</span>
+          <span className='text-sm font-medium'>{truncatedAccount}</span>
           <span className='mt-1 text-xs text-[#595B5A]'>{label}</span>
         </div>
       </div>

--- a/src/app/wallet/funds-flow.tsx
+++ b/src/app/wallet/funds-flow.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import React from 'react';
 
 import { Spinner } from '@/components/common';
+import { formatWalletAddress } from '@/app/wallet/utils';
 
 interface FundsFlowProps {
   icon: React.ReactNode;
@@ -22,7 +23,6 @@ const BalanceItem: React.FC<BalanceItemProps> = ({
   account,
   balance,
 }) => {
-  const truncatedAccount = `${account.slice(0, 5)}...${account.slice(-5)}`;
   return (
     <div className='flex items-center justify-between'>
       <div className='flex items-center gap-3'>
@@ -30,7 +30,9 @@ const BalanceItem: React.FC<BalanceItemProps> = ({
           {icon}
         </span>
         <div className='flex flex-col'>
-          <span className='text-sm font-medium'>{truncatedAccount}</span>
+          <span className='text-sm font-medium'>
+            {formatWalletAddress(account)}
+          </span>
           <span className='mt-1 text-xs text-[#595B5A]'>{label}</span>
         </div>
       </div>

--- a/src/app/wallet/funds-flow.tsx
+++ b/src/app/wallet/funds-flow.tsx
@@ -2,7 +2,7 @@ import Link from 'next/link';
 import React from 'react';
 
 import { Spinner } from '@/components/common';
-import { formatWalletAddress } from '@/app/wallet/utils';
+import { formatCurrency, formatWalletAddress } from '@/app/wallet/utils';
 
 interface FundsFlowProps {
   icon: React.ReactNode;
@@ -37,7 +37,7 @@ const BalanceItem: React.FC<BalanceItemProps> = ({
         </div>
       </div>
       <span className='text-sm font-medium'>
-        {Number(balance).toLocaleString()} USDC
+        {formatCurrency(balance)} USDC
       </span>
     </div>
   );
@@ -64,7 +64,7 @@ export const FundsFlow: React.FC<
             </span>
           </div>
           <div className='text-xl font-semibold'>
-            {Number(balance).toLocaleString()} USDC
+            {formatCurrency(balance)} USDC
           </div>
         </div>
 

--- a/src/app/wallet/utils.tsx
+++ b/src/app/wallet/utils.tsx
@@ -1,3 +1,11 @@
-export const formatWalletAddress = (account: string) => {
+export const formatWalletAddress = (account: string): string => {
   return `${account.slice(0, 5)}...${account.slice(-5)}`;
+};
+
+export const formatCurrency = (currency: string): string => {
+  return Number(currency).toLocaleString();
+};
+
+export const formatTransactionDate = (date: string): string => {
+  return date.split(',')[0];
 };

--- a/src/app/wallet/utils.tsx
+++ b/src/app/wallet/utils.tsx
@@ -1,0 +1,3 @@
+export const formatWalletAddress = (account: string) => {
+  return `${account.slice(0, 5)}...${account.slice(-5)}`;
+};

--- a/src/app/wallet/wallet-balance.tsx
+++ b/src/app/wallet/wallet-balance.tsx
@@ -9,6 +9,7 @@ import { WalletSendDialog } from '@/app/wallet/wallet-send-dialog';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useCombinedBalance } from '@/hooks/wallet/useCombinedBalance';
+import { formatBalance } from '@/app/wallet/utils';
 
 interface WalletBalanceProps {
   usdcBalance: string;
@@ -63,7 +64,7 @@ export const WalletBalance: React.FC<WalletBalanceProps> = ({
                 <Skeleton className='h-[30px] w-32 bg-gray-300 leading-[38px]' />
               ) : (
                 <div className='text-3xl font-semibold'>
-                  {Number(usdcBalance).toLocaleString()} USDC
+                  {formatBalance(usdcBalance)} USDC
                 </div>
               )}
             </div>

--- a/src/app/wallet/wallet-balance.tsx
+++ b/src/app/wallet/wallet-balance.tsx
@@ -43,7 +43,7 @@ export const WalletBalance: React.FC<WalletBalanceProps> = ({
   );
 
   return (
-    <div className='min-h-[100%] min-w-80 rounded-3xl bg-white shadow-[0px_10px_30px_0px_#00000014]'>
+    <div className='min-h-[100%] rounded-3xl bg-white shadow-[0px_10px_30px_0px_#00000014]'>
       <div className='flex flex-col gap-1'>
         <div className='flex items-center justify-between p-6 pb-0'>
           <div>

--- a/src/app/wallet/wallet-balance.tsx
+++ b/src/app/wallet/wallet-balance.tsx
@@ -9,7 +9,7 @@ import { WalletSendDialog } from '@/app/wallet/wallet-send-dialog';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useCombinedBalance } from '@/hooks/wallet/useCombinedBalance';
-import { formatBalance } from '@/app/wallet/utils';
+import { formatCurrency } from '@/app/wallet/utils';
 
 interface WalletBalanceProps {
   usdcBalance: string;
@@ -64,7 +64,7 @@ export const WalletBalance: React.FC<WalletBalanceProps> = ({
                 <Skeleton className='h-[30px] w-32 bg-gray-300 leading-[38px]' />
               ) : (
                 <div className='text-3xl font-semibold'>
-                  {formatBalance(usdcBalance)} USDC
+                  {formatCurrency(usdcBalance)} USDC
                 </div>
               )}
             </div>

--- a/src/app/wallet/wallet-container.tsx
+++ b/src/app/wallet/wallet-container.tsx
@@ -121,9 +121,9 @@ export const WalletContainer = () => {
   return (
     <Authenticated>
       <Header />
-      <div className='container my-16 pb-8'>
+      <div className='container my-16 max-w-[1080px] pb-8'>
         <div className='flex flex-col items-center justify-center gap-6 lg:flex-row'>
-          <div className='lg:w-8/12'>
+          <div className='w-full'>
             <WalletBalance
               balanceHistoryIn={
                 !transactions.money_in


### PR DESCRIPTION
# [SRBT-330] Adjusted wallet container width + added wallet truncation

**Changes**

- Wallet container width has been adjusted to be a maximum of 1080px as per the Figma.
- Wallet Address are now truncated to only show the first three digits and last four digits.

# Screenshots

*Using mock data*
![Screenshot 2024-11-20 at 9 09 34 AM](https://github.com/user-attachments/assets/b42d760a-9a10-4207-951c-4257a7d56c1c)

