### PR TITLE
Fix: Tooltip Not Appearing for "Add Section Title"

### DIFF
--- a/src/components/profile/widgets/add-widgets.tsx
+++ b/src/components/profile/widgets/add-widgets.tsx
@@ -208,20 +208,14 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
             <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <label
-                    className={cn(
-                      'hover:text-sorbet align-center flex cursor-pointer items-center justify-center',
-                      loading && loadingClasses
-                    )}
+                  <Button
+                    variant='ghost'
+                    className='h-fit p-0'
+                    onClick={addSectionTitle}
+                    disabled={loading}
                   >
-                    <input
-                      type='button'
-                      className='hidden'
-                      onClick={addSectionTitle}
-                      disabled={loading}
-                    />
-                    <SectionTitleIcon width={20} height={20} />
-                  </label>
+                    <SectionTitleIcon className='hover:text-sorbet size-5' />
+                  </Button>
                 </TooltipTrigger>
                 <TooltipContent>Add section title</TooltipContent>
               </Tooltip>
@@ -258,19 +252,11 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
 /** Local component for achieving purple effect on a custom icon */
 interface SectionTitleIconProps {
   className?: string;
-  width?: number | string; // Allow dynamic width
-  height?: number | string; // Allow dynamic height
 }
-const SectionTitleIcon: React.FC<SectionTitleIconProps> = ({
-  className,
-  width = 20,
-  height = 20,
-}) => {
+const SectionTitleIcon: React.FC<SectionTitleIconProps> = ({ className }) => {
   return (
     <div>
       <svg
-        width={width}
-        height={height}
         viewBox='0 0 20 20'
         fill='none'
         xmlns='http://www.w3.org/2000/svg'

--- a/src/components/profile/widgets/add-widgets.tsx
+++ b/src/components/profile/widgets/add-widgets.tsx
@@ -204,20 +204,31 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
         </div>
 
         <div className='flex items-center gap-2'>
-          <TooltipProvider>
-            {featureFlags.sectionTitles && (
+          {featureFlags.sectionTitles && (
+            <TooltipProvider>
               <Tooltip>
                 <TooltipTrigger asChild>
-                  <SectionTitleIcon
-                    onClick={addSectionTitle}
-                    className='hover:text-sorbet'
-                    width={20}
-                    height={20}
-                  />
+                  <label
+                    className={cn(
+                      'hover:text-sorbet align-center flex cursor-pointer items-center justify-center',
+                      loading && loadingClasses
+                    )}
+                  >
+                    <input
+                      type='button'
+                      className='hidden'
+                      onClick={addSectionTitle}
+                      disabled={loading}
+                    />
+
+                    <SectionTitleIcon width={20} height={20} />
+                  </label>
                 </TooltipTrigger>
                 <TooltipContent>Add section title</TooltipContent>
               </Tooltip>
-            )}
+            </TooltipProvider>
+          )}
+          <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
                 <label
@@ -253,49 +264,56 @@ interface SectionTitleIconProps {
   height?: number | string; // Allow dynamic height
 }
 const SectionTitleIcon: React.FC<SectionTitleIconProps> = ({
-  onClick,
   className,
   width = 20,
   height = 20,
 }) => {
   return (
-    <svg
-      onClick={onClick}
-      width={width}
-      height={height}
-      viewBox='0 0 20 20'
-      fill='none'
-      xmlns='http://www.w3.org/2000/svg'
-      className={`group cursor-pointer transition-colors ${className}`}
-    >
-      <rect
-        x='1'
-        y='1'
-        width='18'
-        height='18'
-        rx='3'
-        stroke='currentColor'
-        strokeWidth='2'
-      />
-      <rect x='3.5' y='4.75' width='10' height='2' rx='1' fill='currentColor' />
-      <rect
-        x='3.5'
-        y='9.25'
-        width='6'
-        height='6'
-        rx='2'
-        fill='#A8A8A8'
-        className='group-hover:fill-current'
-      />
-      <rect
-        x='10.5'
-        y='9.25'
-        width='6'
-        height='6'
-        rx='2'
-        fill='#A8A8A8'
-        className='group-hover:fill-current'
-      />
-    </svg>
+    <div>
+      <svg
+        width={width}
+        height={height}
+        viewBox='0 0 20 20'
+        fill='none'
+        xmlns='http://www.w3.org/2000/svg'
+        className={`group cursor-pointer transition-colors ${className}`}
+      >
+        <rect
+          x='1'
+          y='1'
+          width='18'
+          height='18'
+          rx='3'
+          stroke='currentColor'
+          strokeWidth='2'
+        />
+        <rect
+          x='3.5'
+          y='4.75'
+          width='10'
+          height='2'
+          rx='1'
+          fill='currentColor'
+        />
+        <rect
+          x='3.5'
+          y='9.25'
+          width='6'
+          height='6'
+          rx='2'
+          fill='#A8A8A8'
+          className='group-hover:fill-current'
+        />
+        <rect
+          x='10.5'
+          y='9.25'
+          width='6'
+          height='6'
+          rx='2'
+          fill='#A8A8A8'
+          className='group-hover:fill-current'
+        />
+      </svg>
+    </div>
   );
 };

--- a/src/components/profile/widgets/add-widgets.tsx
+++ b/src/components/profile/widgets/add-widgets.tsx
@@ -220,7 +220,6 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
                       onClick={addSectionTitle}
                       disabled={loading}
                     />
-
                     <SectionTitleIcon width={20} height={20} />
                   </label>
                 </TooltipTrigger>
@@ -258,7 +257,6 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
 
 /** Local component for achieving purple effect on a custom icon */
 interface SectionTitleIconProps {
-  onClick?: () => void;
   className?: string;
   width?: number | string; // Allow dynamic width
   height?: number | string; // Allow dynamic height


### PR DESCRIPTION
# [SRBT-349] Fix: Tooltip Not Appearing for "Add Section Title"

**Changes**

- Refactored the SectionTitleIcon to be wrapped in a `div` instead of an `svg`.  I also refactored the Tooltip Trigger for section titles to be a button. Apparently, Tooltips can only to appear on [buttons](https://github.com/radix-ui/primitives/issues/955#issuecomment-960610209), or elements that require a click / pointer-down interaction – from what I've gathered on the documentation beyond this specific GitHub issue.

# Screenshots

<img width="487" alt="Screenshot 2024-12-03 at 8 57 21 AM" src="https://github.com/user-attachments/assets/a1a38d3f-075c-46b7-9064-a0b581efcf5a">

