### PR TITLE
[SRBT-343] Wallet Page Skeletons for Loading + Shadow Fixes

### DIFF
--- a/src/app/wallet/all/transactions-table.tsx
+++ b/src/app/wallet/all/transactions-table.tsx
@@ -11,6 +11,7 @@ import {
 import { Spinner } from '@/components/common';
 import { DatePickerWithRange } from '@/components/ui/date-range-picker';
 import { env } from '@/lib/env';
+import { Skeleton } from '@/components/ui/skeleton';
 
 export interface TableTransaction {
   account: string;
@@ -46,127 +47,130 @@ const TransactionsTable: React.FC<TransactionsTableProps> = ({
   };
 
   return (
-    <div className='bg-card relative min-h-full rounded-2xl p-6 shadow-md'>
-      {isLoading && (
-        <div className='bg-card absolute inset-0 z-30 flex items-center justify-center rounded-3xl bg-opacity-75'>
-          <Spinner />
-        </div>
-      )}
-      {!minimalMode && (
-        <div className='mb-4 grid grid-cols-12 gap-4'>
-          <div className='relative col-span-12 lg:col-span-8'>
-            <div className='pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3'>
-              <Search className='size-5' />
-            </div>
-            <input
-              type='text'
-              placeholder='Search'
-              value={searchValue}
-              onChange={(e) => onSearchChange && onSearchChange(e.target.value)}
-              className='w-full rounded-md border border-gray-300 px-10 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500'
-            />
-          </div>
+    <>
+      {isLoading ? (
+        <Skeleton className='h-24 rounded-3xl bg-gray-300 shadow-md' />
+      ) : (
+        <div className='bg-card relative min-h-full rounded-2xl p-6 shadow-md'>
+          {!minimalMode && (
+            <div className='mb-4 grid grid-cols-12 gap-4'>
+              <div className='relative col-span-12 lg:col-span-8'>
+                <div className='pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3'>
+                  <Search className='size-5' />
+                </div>
+                <input
+                  type='text'
+                  placeholder='Search'
+                  value={searchValue}
+                  onChange={(e) =>
+                    onSearchChange && onSearchChange(e.target.value)
+                  }
+                  className='w-full rounded-md border border-gray-300 px-10 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500'
+                />
+              </div>
 
-          <div className='relative col-span-12 md:col-span-4 lg:col-span-2'>
-            {onDateRangeChange && (
-              <DatePickerWithRange
-                date={dateRange}
-                onDateChange={onDateRangeChange}
-                triggerButton={
-                  <button className='text-md text-muted-foreground flex w-full items-center justify-center rounded-md border border-gray-300 px-4 py-2 focus:outline-none'>
-                    Date
-                    <ChevronDown className='ml-1 size-4' />
-                  </button>
-                }
-              />
-            )}
-          </div>
-          <div className='relative col-span-12 md:col-span-4 lg:col-span-2'>
-            <button
-              className='text-md text-muted-foreground flex w-full items-center justify-center rounded-md border border-gray-300 px-4 py-2 focus:outline-none'
-              onClick={onClearAll}
-            >
-              Clear All
-            </button>
-          </div>
+              <div className='relative col-span-12 md:col-span-4 lg:col-span-2'>
+                {onDateRangeChange && (
+                  <DatePickerWithRange
+                    date={dateRange}
+                    onDateChange={onDateRangeChange}
+                    triggerButton={
+                      <button className='text-md text-muted-foreground flex w-full items-center justify-center rounded-md border border-gray-300 px-4 py-2 focus:outline-none'>
+                        Date
+                        <ChevronDown className='ml-1 size-4' />
+                      </button>
+                    }
+                  />
+                )}
+              </div>
+              <div className='relative col-span-12 md:col-span-4 lg:col-span-2'>
+                <button
+                  className='text-md text-muted-foreground flex w-full items-center justify-center rounded-md border border-gray-300 px-4 py-2 focus:outline-none'
+                  onClick={onClearAll}
+                >
+                  Clear All
+                </button>
+              </div>
+            </div>
+          )}
+          <table className='min-w-full divide-y divide-gray-200'>
+            <thead className='border-b'>
+              <tr>
+                <th
+                  scope='col'
+                  className='w-2/5 py-3 text-left text-xs font-medium text-gray-500'
+                >
+                  To/From
+                </th>
+                <th
+                  scope='col'
+                  className='w-1/5 py-3 text-left text-xs font-medium text-gray-500'
+                >
+                  Date
+                </th>
+                <th
+                  scope='col'
+                  className='w-1/5 py-3 text-right text-xs font-medium text-gray-500'
+                >
+                  Amount
+                </th>
+              </tr>
+            </thead>
+            <tbody className='bg-white'>
+              {transactions &&
+                transactions.map((transaction, index) => (
+                  <tr key={index}>
+                    <td className='w-2/5 whitespace-nowrap py-4'>
+                      <div className='flex items-center'>
+                        <div className='h-12 w-12 flex-shrink-0'>
+                          <span className='flex h-12 w-12 items-center justify-center rounded-full bg-[#D7D7D7]'>
+                            {transaction.type === 'Sent' && (
+                              <ArrowDown className='size-6 text-white' />
+                            )}
+                            {transaction.type === 'Received' && (
+                              <Send className='size-6 text-white' />
+                            )}
+                            {transaction.type === 'Self-transfer' && (
+                              <Plus className='size-6 text-white' />
+                            )}
+                          </span>
+                        </div>
+                        <div className='ml-4'>
+                          <div className='text-sm font-medium text-gray-900'>
+                            {formatWalletAddress(transaction.account)}
+                          </div>
+                          <div className='mt-1 text-xs text-[#595B5A]'>
+                            {transaction.type === 'Self-transfer'
+                              ? 'Added'
+                              : transaction.type}
+                          </div>
+                        </div>
+                      </div>
+                    </td>
+                    <td className='w-1/5 whitespace-nowrap py-4'>
+                      <div className='text-sm font-medium text-gray-900'>
+                        {formatTransactionDate(transaction.date)}
+                      </div>
+                    </td>
+                    <td
+                      className='w-1/5 cursor-pointer whitespace-nowrap py-4'
+                      onClick={() => handleTxnClick(transaction.hash)}
+                    >
+                      <div className='flex items-center justify-end gap-2'>
+                        <div className='text-sm font-medium'>
+                          {transaction.type === 'Sent' ? '-' : '+'}{' '}
+                          {formatCurrency(transaction.amount)} USDC
+                        </div>
+                        <LinkExternal02 className='size-[1.125rem] text-[#595B5A]' />
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+            </tbody>
+          </table>
         </div>
       )}
-      <table className='min-w-full divide-y divide-gray-200'>
-        <thead className='border-b'>
-          <tr>
-            <th
-              scope='col'
-              className='w-2/5 py-3 text-left text-xs font-medium text-gray-500'
-            >
-              To/From
-            </th>
-            <th
-              scope='col'
-              className='w-1/5 py-3 text-left text-xs font-medium text-gray-500'
-            >
-              Date
-            </th>
-            <th
-              scope='col'
-              className='w-1/5 py-3 text-right text-xs font-medium text-gray-500'
-            >
-              Amount
-            </th>
-          </tr>
-        </thead>
-        <tbody className='bg-white'>
-          {transactions &&
-            transactions.map((transaction, index) => (
-              <tr key={index}>
-                <td className='w-2/5 whitespace-nowrap py-4'>
-                  <div className='flex items-center'>
-                    <div className='h-12 w-12 flex-shrink-0'>
-                      <span className='flex h-12 w-12 items-center justify-center rounded-full bg-[#D7D7D7]'>
-                        {transaction.type === 'Sent' && (
-                          <ArrowDown className='size-6 text-white' />
-                        )}
-                        {transaction.type === 'Received' && (
-                          <Send className='size-6 text-white' />
-                        )}
-                        {transaction.type === 'Self-transfer' && (
-                          <Plus className='size-6 text-white' />
-                        )}
-                      </span>
-                    </div>
-                    <div className='ml-4'>
-                      <div className='text-sm font-medium text-gray-900'>
-                        {formatWalletAddress(transaction.account)}
-                      </div>
-                      <div className='mt-1 text-xs text-[#595B5A]'>
-                        {transaction.type === 'Self-transfer'
-                          ? 'Added'
-                          : transaction.type}
-                      </div>
-                    </div>
-                  </div>
-                </td>
-                <td className='w-1/5 whitespace-nowrap py-4'>
-                  <div className='text-sm font-medium text-gray-900'>
-                    {formatTransactionDate(transaction.date)}
-                  </div>
-                </td>
-                <td
-                  className='w-1/5 cursor-pointer whitespace-nowrap py-4'
-                  onClick={() => handleTxnClick(transaction.hash)}
-                >
-                  <div className='flex items-center justify-end gap-2'>
-                    <div className='text-sm font-medium'>
-                      {transaction.type === 'Sent' ? '-' : '+'}{' '}
-                      {formatCurrency(transaction.amount)} USDC
-                    </div>
-                    <LinkExternal02 className='size-[1.125rem] text-[#595B5A]' />
-                  </div>
-                </td>
-              </tr>
-            ))}
-        </tbody>
-      </table>
-    </div>
+    </>
   );
 };
 

--- a/src/app/wallet/funds-flow.tsx
+++ b/src/app/wallet/funds-flow.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 
 import { formatCurrency, formatWalletAddress } from '@/app/wallet/utils';
 import { Spinner } from '@/components/common';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface FundsFlowProps {
   icon: React.ReactNode;
@@ -47,55 +48,61 @@ export const FundsFlow: React.FC<
   FundsFlowProps & { items: BalanceItemProps[] | undefined; isLoading: boolean }
 > = ({ title, balance, icon, items, isLoading }) => {
   return (
-    <div className='bg-card flex min-h-full flex-col rounded-3xl p-6 shadow-[0px_10px_30px_0px_#00000014]'>
-      {isLoading && (
-        <div className='bg-card absolute inset-0 flex items-center justify-center rounded-3xl bg-opacity-75'>
-          <Spinner />
+    <>
+      {isLoading || balance === '' ? (
+        <Skeleton className='h-44 rounded-3xl bg-gray-300 shadow-md' />
+      ) : (
+        <div className='bg-card flex min-h-full flex-col rounded-3xl p-6 shadow-md'>
+          {/** isLoading && (
+          <div className='bg-card absolute inset-0 flex items-center justify-center rounded-3xl bg-opacity-75'>
+            <Spinner />
+          </div>
+        ) */}
+          <div className='flex flex-grow flex-col gap-2'>
+            <div className='flex items-center justify-between'>
+              <div className='flex items-center gap-2'>
+                <span className='bg-foreground text-muted rounded-full p-1.5'>
+                  {icon}
+                </span>
+                <span className='text-muted-foreground text-sm font-medium uppercase'>
+                  {title}
+                </span>
+              </div>
+              <div className='text-xl font-semibold'>
+                {formatCurrency(balance)} USDC
+              </div>
+            </div>
+
+            <div className='border-border mt-4 border-t'></div>
+            <div className='mt-4 flex-grow'>
+              <div className='flex flex-col gap-4'>
+                {(!items || items.length < 1) && !isLoading && (
+                  <div className='text-muted-foreground text-center text-sm'>
+                    No transactions found
+                  </div>
+                )}
+                {items &&
+                  items.map((item, index) => (
+                    <BalanceItem
+                      key={index}
+                      icon={item.icon}
+                      label={item.label}
+                      account={item.account}
+                      balance={item.balance}
+                    />
+                  ))}
+              </div>
+            </div>
+          </div>
+          <div className='mt-auto flex justify-end pt-4'>
+            <Link href='/wallet/all'>
+              <div className='text-sorbet cursor-pointer text-sm font-semibold'>
+                View all
+              </div>
+            </Link>
+          </div>
         </div>
       )}
-      <div className='flex flex-grow flex-col gap-2'>
-        <div className='flex items-center justify-between'>
-          <div className='flex items-center gap-2'>
-            <span className='bg-foreground text-muted rounded-full p-1.5'>
-              {icon}
-            </span>
-            <span className='text-muted-foreground text-sm font-medium uppercase'>
-              {title}
-            </span>
-          </div>
-          <div className='text-xl font-semibold'>
-            {formatCurrency(balance)} USDC
-          </div>
-        </div>
-
-        <div className='border-border mt-4 border-t'></div>
-        <div className='mt-4 flex-grow'>
-          <div className='flex flex-col gap-4'>
-            {(!items || items.length < 1) && !isLoading && (
-              <div className='text-muted-foreground text-center text-sm'>
-                No transactions found
-              </div>
-            )}
-            {items &&
-              items.map((item, index) => (
-                <BalanceItem
-                  key={index}
-                  icon={item.icon}
-                  label={item.label}
-                  account={item.account}
-                  balance={item.balance}
-                />
-              ))}
-          </div>
-        </div>
-      </div>
-      <div className='mt-auto flex justify-end pt-4'>
-        <Link href='/wallet/all'>
-          <div className='text-sorbet cursor-pointer text-sm font-semibold'>
-            View all
-          </div>
-        </Link>
-      </div>
-    </div>
+    </>
   );
 };

--- a/src/app/wallet/funds-flow.tsx
+++ b/src/app/wallet/funds-flow.tsx
@@ -53,11 +53,6 @@ export const FundsFlow: React.FC<
         <Skeleton className='h-44 rounded-3xl bg-gray-300 shadow-md' />
       ) : (
         <div className='bg-card flex min-h-full flex-col rounded-3xl p-6 shadow-md'>
-          {/** isLoading && (
-          <div className='bg-card absolute inset-0 flex items-center justify-center rounded-3xl bg-opacity-75'>
-            <Spinner />
-          </div>
-        ) */}
           <div className='flex flex-grow flex-col gap-2'>
             <div className='flex items-center justify-between'>
               <div className='flex items-center gap-2'>

--- a/src/app/wallet/my-accounts.tsx
+++ b/src/app/wallet/my-accounts.tsx
@@ -3,34 +3,45 @@ import Image from 'next/image';
 
 import { formatCurrency, formatWalletAddress } from '@/app/wallet/utils';
 import { CopyIconButton } from '@/components/common/copy-button/copy-icon-button';
+import { Skeleton } from '@/components/ui/skeleton';
 
 interface MyAccountsProps {
   usdcBalance: string;
   address: string | null;
+  isLoading: boolean;
 }
 
 export const MyAccounts: React.FC<MyAccountsProps> = ({
   usdcBalance,
   address,
+  isLoading,
 }) => {
   return (
-    <div className='bg-background min-h-full min-w-[360px] rounded-2xl p-6 shadow-md'>
-      <div className='flex items-center gap-2'>
-        <span className='bg-foreground text-muted rounded-full p-2'>
-          <Bank className='size-[1.125rem]' />
-        </span>
-        <span className='text-md font-medium text-[#595B5A]'>MY ACCOUNTS</span>
-      </div>
-      <div className='bg-border my-4 h-[1px] w-full' />
-      <div>
-        {/** for now, it's only USDC but this will be refactored into multiple account items */}
-        <USDCAccountItem
-          icon={<Wallet03 className='size-3' />}
-          address={address}
-          balance={usdcBalance}
-        ></USDCAccountItem>
-      </div>
-    </div>
+    <>
+      {isLoading || usdcBalance === '' ? (
+        <Skeleton className='h-[366px] rounded-3xl bg-gray-300 shadow-md' />
+      ) : (
+        <div className='bg-background min-h-full min-w-[360px] rounded-2xl p-6 shadow-md'>
+          <div className='flex items-center gap-2'>
+            <span className='bg-foreground text-muted rounded-full p-2'>
+              <Bank className='size-[1.125rem]' />
+            </span>
+            <span className='text-md font-medium text-[#595B5A]'>
+              MY ACCOUNTS
+            </span>
+          </div>
+          <div className='bg-border my-4 h-[1px] w-full' />
+          <div>
+            {/** for now, it's only USDC but this will be refactored into multiple account items */}
+            <USDCAccountItem
+              icon={<Wallet03 className='size-3' />}
+              address={address}
+              balance={usdcBalance}
+            ></USDCAccountItem>
+          </div>
+        </div>
+      )}
+    </>
   );
 };
 

--- a/src/app/wallet/wallet-balance.tsx
+++ b/src/app/wallet/wallet-balance.tsx
@@ -22,6 +22,7 @@ interface WalletBalanceProps {
   balanceHistoryIn: { date: string; balance: string }[] | undefined;
   balanceHistoryOut: { date: string; balance: string }[] | undefined;
   selectedDuration: string;
+  isLoading: boolean;
   onTxnDurationChange: Dispatch<SetStateAction<string>>;
 }
 
@@ -34,6 +35,7 @@ export const WalletBalance: React.FC<WalletBalanceProps> = ({
   onTxnDurationChange,
   balanceHistoryIn,
   balanceHistoryOut,
+  isLoading,
 }) => {
   const [open, setOpen] = useState<boolean>(false);
 
@@ -44,59 +46,66 @@ export const WalletBalance: React.FC<WalletBalanceProps> = ({
   );
 
   return (
-    <div className='min-h-full rounded-3xl bg-white shadow-[0px_10px_30px_0px_#00000014]'>
-      <div className='flex flex-col gap-1'>
-        <div className='flex items-center justify-between p-6 pb-0'>
-          <div>
-            <div className='flex items-center gap-2'>
-              <span className='rounded-full bg-black p-2 text-white'>
-                <Wallet03 className='size-[1.125rem]' />
-              </span>
-              <span className='text-md font-medium text-[#595B5A]'>
-                BALANCE
-              </span>
-              {percentChange !== 0 && (
-                <PercentageChange percentChange={percentChange} />
-              )}
-            </div>
-            <div className='mt-2 flex'>
-              {isBalanceLoading ? (
-                <Skeleton className='h-[30px] w-32 bg-gray-300 leading-[38px]' />
-              ) : (
-                <div className='text-3xl font-semibold'>
-                  {formatCurrency(usdcBalance)} USDC
+    <>
+      {isLoading || usdcBalance === '' ? (
+        <Skeleton className='h-[366px] rounded-3xl bg-gray-300 shadow-md' />
+      ) : (
+        <div className='min-h-full rounded-3xl bg-white shadow-md'>
+          <div className='flex flex-col gap-1'>
+            <div className='flex items-center justify-between p-6 pb-0'>
+              <div>
+                <div className='flex items-center gap-2'>
+                  <span className='rounded-full bg-black p-2 text-white'>
+                    <Wallet03 className='size-[1.125rem]' />
+                  </span>
+                  <span className='text-md font-medium text-[#595B5A]'>
+                    BALANCE
+                  </span>
+                  {percentChange !== 0 && (
+                    <PercentageChange percentChange={percentChange} />
+                  )}
                 </div>
-              )}
+                <div className='mt-2 flex'>
+                  {isBalanceLoading || usdcBalance === '' ? (
+                    // Show skeleton with the same height as the balance display
+                    <Skeleton className='h-[36px] w-32 bg-gray-300 leading-[38px]' />
+                  ) : (
+                    <div className='text-3xl font-semibold'>
+                      {formatCurrency(usdcBalance)} USDC
+                    </div>
+                  )}
+                </div>
+              </div>
+              <div className='flex gap-4'>
+                <CircleButton
+                  icon={<Plus className='size-6' />}
+                  label='Deposit'
+                  onClick={onTopUp}
+                />
+                <CircleButton
+                  icon={<Send01 className='size-6' />}
+                  label='Send'
+                  onClick={() => setOpen(true)}
+                />
+                <WalletSendDialog
+                  open={open}
+                  setOpen={setOpen}
+                  sendUSDC={sendUSDC}
+                  usdcBalance={usdcBalance}
+                />
+              </div>
             </div>
-          </div>
-          <div className='flex gap-4'>
-            <CircleButton
-              icon={<Plus className='size-6' />}
-              label='Deposit'
-              onClick={onTopUp}
-            />
-            <CircleButton
-              icon={<Send01 className='size-6' />}
-              label='Send'
-              onClick={() => setOpen(true)}
-            />
-            <WalletSendDialog
-              open={open}
-              setOpen={setOpen}
-              sendUSDC={sendUSDC}
-              usdcBalance={usdcBalance}
-            />
+            <div className='mb-2 ml-6 mt-2'>
+              <SelectDuration
+                selectedValue={selectedDuration}
+                onChange={(value) => onTxnDurationChange(value)}
+              />
+            </div>
+            <BalanceChart balanceHistory={cumulativeBalanceHistory} />
           </div>
         </div>
-        <div className='mb-2 ml-6 mt-2'>
-          <SelectDuration
-            selectedValue={selectedDuration}
-            onChange={(value) => onTxnDurationChange(value)}
-          />
-        </div>
-        <BalanceChart balanceHistory={cumulativeBalanceHistory} />
-      </div>
-    </div>
+      )}
+    </>
   );
 };
 

--- a/src/app/wallet/wallet-balance.tsx
+++ b/src/app/wallet/wallet-balance.tsx
@@ -68,7 +68,7 @@ export const WalletBalance: React.FC<WalletBalanceProps> = ({
                 <div className='mt-2 flex'>
                   {isBalanceLoading || usdcBalance === '' ? (
                     // Show skeleton with the same height as the balance display
-                    <Skeleton className='h-[36px] w-32 bg-gray-300 leading-[38px]' />
+                    <Skeleton className='h-9 w-32 bg-gray-300' />
                   ) : (
                     <div className='text-3xl font-semibold'>
                       {formatCurrency(usdcBalance)} USDC

--- a/src/app/wallet/wallet-container.tsx
+++ b/src/app/wallet/wallet-container.tsx
@@ -227,33 +227,29 @@ export const WalletContainer = () => {
               </div>
             </Link>
           </div>
-          {walletAddress && (
-            <TransactionsTable
-              isLoading={loading}
-              minimalMode
-              transactions={
-                !transactions.transactions
-                  ? []
-                  : transactions.transactions.map(
-                      (transaction: Transaction) => ({
-                        type:
-                          transaction.sender.toLowerCase() ===
-                          walletAddress.toLowerCase()
-                            ? 'Sent'
-                            : 'Received',
-                        account:
-                          transaction.sender.toLowerCase() ===
-                          walletAddress.toLowerCase()
-                            ? transaction.receiver
-                            : transaction.sender,
-                        date: transaction.timestamp,
-                        amount: transaction.value,
-                        hash: transaction.hash,
-                      })
-                    )
-              }
-            />
-          )}
+          <TransactionsTable
+            isLoading={loading}
+            minimalMode
+            transactions={
+              !transactions.transactions
+                ? []
+                : transactions.transactions.map((transaction: Transaction) => ({
+                    type:
+                      transaction.sender.toLowerCase() ===
+                      walletAddress?.toLowerCase()
+                        ? 'Sent'
+                        : 'Received',
+                    account:
+                      transaction.sender.toLowerCase() ===
+                      walletAddress?.toLowerCase()
+                        ? transaction.receiver
+                        : transaction.sender,
+                    date: transaction.timestamp,
+                    amount: transaction.value,
+                    hash: transaction.hash,
+                  }))
+            }
+          />
         </div>
       </div>
     </Authenticated>

--- a/src/app/wallet/wallet-container.tsx
+++ b/src/app/wallet/wallet-container.tsx
@@ -4,7 +4,7 @@ import { useFundWallet } from '@privy-io/react-auth';
 import { useSmartWallets } from '@privy-io/react-auth/smart-wallets';
 import { ArrowDown, ArrowUp, Plus } from 'lucide-react';
 import Link from 'next/link';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { encodeFunctionData, parseUnits } from 'viem';
 import { base, baseSepolia } from 'viem/chains';
@@ -33,7 +33,7 @@ export const WalletContainer = () => {
 
   const { fundWallet } = useFundWallet();
 
-  const [loading, setLoading] = useState<boolean>(false);
+  const [loading, setLoading] = useState<boolean>(true);
 
   const [selectedDuration, setSelectedDuration] = useState<string>('30');
 
@@ -69,8 +69,9 @@ export const WalletContainer = () => {
           amount: defaultFundAmount,
           asset: 'USDC',
         });
-        setReload(!reload); // trigger reload to refresh wallet amount
       }
+      // TODO: see if setReload() can be removed, fundWallet() is technically finished after just opening the modal.
+      setReload(!reload);
     } catch (e) {
       toast('Something went wrong', {
         description:
@@ -103,6 +104,7 @@ export const WalletContainer = () => {
       });
 
       setReload(!reload);
+
       return transferTransactionHash;
     }
   };
@@ -111,13 +113,13 @@ export const WalletContainer = () => {
     (async () => {
       await fetchTransactions();
     })();
-  }, [walletAddress, reload, fetchTransactions]);
+  }, [fetchTransactions, reload]);
 
   useEffect(() => {
     (async () => {
       fetchTransactions(parseInt(selectedDuration, 10));
     })();
-  }, [selectedDuration, fetchTransactions]);
+  }, [fetchTransactions, selectedDuration]);
 
   return (
     <Authenticated>
@@ -146,12 +148,17 @@ export const WalletContainer = () => {
               onTopUp={handleTopUp}
               sendUSDC={handleSendUSDC}
               isBalanceLoading={balanceLoading}
+              isLoading={loading}
               selectedDuration={selectedDuration}
               onTxnDurationChange={setSelectedDuration}
             />
           </div>
           <div className='lg:w-4/12'>
-            <MyAccounts usdcBalance={usdcBalance} address={walletAddress} />
+            <MyAccounts
+              usdcBalance={usdcBalance}
+              address={walletAddress}
+              isLoading={loading}
+            />
           </div>
         </div>
         <div className='mb-6 mt-12 flex justify-between'>

--- a/src/app/wallet/wallet-container.tsx
+++ b/src/app/wallet/wallet-container.tsx
@@ -4,7 +4,7 @@ import { useFundWallet } from '@privy-io/react-auth';
 import { useSmartWallets } from '@privy-io/react-auth/smart-wallets';
 import { ArrowDown, ArrowUp, Plus } from 'lucide-react';
 import Link from 'next/link';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { toast } from 'sonner';
 import { encodeFunctionData, parseUnits } from 'viem';
 import { base, baseSepolia } from 'viem/chains';
@@ -70,7 +70,8 @@ export const WalletContainer = () => {
           asset: 'USDC',
         });
       }
-      // TODO: see if setReload() can be removed, fundWallet() is technically finished after just opening the modal.
+
+      // update the value of reload here to re-fetch transactions after the deposit
       setReload(!reload);
     } catch (e) {
       toast('Something went wrong', {
@@ -103,6 +104,7 @@ export const WalletContainer = () => {
         data: transferData,
       });
 
+      // update the value of reload here to re-fetch transactions after the deposit
       setReload(!reload);
 
       return transferTransactionHash;

--- a/src/hooks/web3/use-wallet-balances.ts
+++ b/src/hooks/web3/use-wallet-balances.ts
@@ -14,9 +14,9 @@ export const useWalletBalances = (
   walletAddress: string | null,
   reload?: boolean
 ) => {
-  const [ethBalance, setEthBalance] = useState<string>('0');
-  const [usdcBalance, setUsdcBalance] = useState<string>('0');
-  const [loading, setLoading] = useState(true);
+  const [ethBalance, setEthBalance] = useState<string>('');
+  const [usdcBalance, setUsdcBalance] = useState<string>('');
+  const [loading, setLoading] = useState(false);
 
   // TODO: convert to RQ so we can invalidate whenever a usdc is sent or received
 


### PR DESCRIPTION
[SRBT-343] Wallet Page Skeletons for Loading + Shadow Fixes

Also a correction for [SRBT-344](https://linear.app/mysorbet/issue/SRBT-344/consistent-shadows-on-wallet-page-cards) and [SRBT-336](https://linear.app/mysorbet/issue/SRBT-336/wallet-balance-update-delay-may-cause-user-confusion) 

**Changes**

- When the page is loading, skeleton components are rendered instead of the actual cards themselves to reduce confusion about what the actual wallet balance is, etc. In the case of the Wallet Balance Card, there's a skeleton component for just the balance actual value changing (regarding SRBT-336), since the balance loading != page loading necessarily (like in the case of adding funds)
- All cards now have the same box-shadow value (`shadow-md`), instead of arbitrary values

# Screenshots


https://github.com/user-attachments/assets/f3f976ac-47d1-4ab8-b184-29e260a300b7


