### PR TITLE
[SRBT-358] Widget replace and restore images

### DIFF
--- a/src/components/profile/widgets/add-widgets.tsx
+++ b/src/components/profile/widgets/add-widgets.tsx
@@ -20,7 +20,7 @@ import { cn } from '@/lib/utils';
 
 import { InvalidAlert } from './invalid-alert';
 import {
-  handleImageUpload,
+  checkFileValid,
   isValidUrl,
   normalizeUrl,
   parseWidgetTypeFromUrl,
@@ -44,7 +44,7 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
 }) => {
   const [url, setUrl] = useState<string>('');
   const [error, setError] = useState<string>();
-  const [errorInvalidImage, showErrorInvalidImage] = useState(false);
+  const [errorInvalidImage, setErrorInvalidImage] = useState(false);
   const [disabled, setDisabled] = useState(true);
 
   const handleUrlSubmit = () => {
@@ -96,7 +96,15 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
   };
 
   const handleAddImageClick = (e: React.ChangeEvent<HTMLInputElement>) => {
-    handleImageUpload(e, addUrl, showErrorInvalidImage);
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const valid = checkFileValid(file);
+    if (valid) {
+      // pass in URL for the handleWidgetAdd (so it knows its a photo widget)
+      addUrl('https://storage.googleapis.com', file);
+    } else {
+      setErrorInvalidImage(true);
+    }
   };
 
   const loadingClasses = 'opacity-90 pointer-events-none';
@@ -127,7 +135,7 @@ export const AddWidgets: React.FC<AddWidgetsProps> = ({
       {errorInvalidImage && (
         <div className='animate-in slide-in-from-bottom-8 z-0 mb-2'>
           <InvalidAlert
-            handleAlertVisible={(show: boolean) => showErrorInvalidImage(show)}
+            handleAlertVisible={(show: boolean) => setErrorInvalidImage(show)}
             title='Error uploading file'
           >
             <p className='mt-2'>

--- a/src/components/profile/widgets/modify-image-controls.tsx
+++ b/src/components/profile/widgets/modify-image-controls.tsx
@@ -38,7 +38,6 @@ export const ModifyImageControls: React.FC<ModifyImageControlsProps> = ({
   const dividerClass = 'h-4 w-[2.5px] bg-[#344054] rounded-full mx-2';
 
   const handleAddImageClick = (e: React.ChangeEvent<HTMLInputElement>) => {
-    console.log('bleh');
     handleImageUpload(e, addImage, setErrorInvalidImage, identifier);
   };
 

--- a/src/components/profile/widgets/modify-image-controls.tsx
+++ b/src/components/profile/widgets/modify-image-controls.tsx
@@ -40,7 +40,8 @@ export const ModifyImageControls: React.FC<ModifyImageControlsProps> = ({
   const dividerClass = 'h-4 w-[2.5px] bg-[#344054] rounded-full mx-2';
 
   const handleAddImageClick = (e: React.ChangeEvent<HTMLInputElement>) => {
-    handleImageUpload(e, addImage, setErrorInvalidImage);
+    console.log('bleh');
+    handleImageUpload(e, addImage, setErrorInvalidImage, identifier);
   };
 
   const handleImageRemove = () => {

--- a/src/components/profile/widgets/modify-image-controls.tsx
+++ b/src/components/profile/widgets/modify-image-controls.tsx
@@ -3,7 +3,7 @@ import { Trash2 } from 'lucide-react';
 import { Dispatch, SetStateAction } from 'react';
 import React from 'react';
 
-import { handleImageUpload } from '@/components/profile/widgets/util';
+import { checkFileValid } from '@/components/profile/widgets/util';
 import {
   Tooltip,
   TooltipContent,
@@ -38,7 +38,15 @@ export const ModifyImageControls: React.FC<ModifyImageControlsProps> = ({
   const dividerClass = 'h-4 w-[2.5px] bg-[#344054] rounded-full mx-2';
 
   const handleAddImageClick = (e: React.ChangeEvent<HTMLInputElement>) => {
-    handleImageUpload(e, addImage, setErrorInvalidImage, identifier);
+    const file = e.target.files?.[0];
+    if (!file) return;
+    const valid = checkFileValid(file);
+    if (valid) {
+      // Pass in identifier so the correct widget is modified (for handleNewImageAdd)
+      addImage(identifier, file);
+    } else {
+      setErrorInvalidImage(true);
+    }
   };
 
   const handleImageRemove = () => {

--- a/src/components/profile/widgets/modify-image-controls.tsx
+++ b/src/components/profile/widgets/modify-image-controls.tsx
@@ -19,7 +19,6 @@ interface ModifyImageControlsProps {
   removeImage: (key: string) => Promise<void>;
   setErrorInvalidImage: Dispatch<SetStateAction<boolean>>;
   restoreImage?: (event: React.MouseEvent<HTMLDivElement>) => void;
-  className?: string;
 }
 
 /**
@@ -34,7 +33,6 @@ export const ModifyImageControls: React.FC<ModifyImageControlsProps> = ({
   removeImage,
   setErrorInvalidImage,
   restoreImage,
-  className,
 }) => {
   const btnClass = 'h-4 w-7 flex items-center justify-center';
   const dividerClass = 'h-4 w-[2.5px] bg-[#344054] rounded-full mx-2';
@@ -61,7 +59,7 @@ export const ModifyImageControls: React.FC<ModifyImageControlsProps> = ({
                   onChange={handleAddImageClick}
                   accept='image/*'
                 />
-                <Image03 width={24} height={24} strokeWidth={2.5} />
+                <Image03 width={26} height={26} strokeWidth={2.5} />
               </label>
             </div>
           </TooltipTrigger>
@@ -74,7 +72,7 @@ export const ModifyImageControls: React.FC<ModifyImageControlsProps> = ({
             <Tooltip>
               <TooltipTrigger>
                 <div className={btnClass} onClick={restoreImage}>
-                  <LinkedPictureIcon className='size-5 text-white' />
+                  <LinkedPictureIcon className='size-6 text-white' />
                 </div>
               </TooltipTrigger>
               <TooltipContent>Use website picture</TooltipContent>
@@ -86,7 +84,7 @@ export const ModifyImageControls: React.FC<ModifyImageControlsProps> = ({
             <Tooltip>
               <TooltipTrigger>
                 <div className={btnClass} onClick={handleImageRemove}>
-                  <Trash2 size={18} />
+                  <Trash2 size={22} />
                 </div>
               </TooltipTrigger>
               <TooltipContent>Delete picture</TooltipContent>
@@ -99,7 +97,7 @@ export const ModifyImageControls: React.FC<ModifyImageControlsProps> = ({
             <Tooltip>
               <TooltipTrigger>
                 <div className={btnClass} onClick={restoreImage}>
-                  <LinkedPictureIcon className='text-white' />
+                  <LinkedPictureIcon className='size-6 text-white' />
                 </div>
               </TooltipTrigger>
               <TooltipContent>Use website picture</TooltipContent>

--- a/src/components/profile/widgets/util.tsx
+++ b/src/components/profile/widgets/util.tsx
@@ -204,7 +204,6 @@ export const handleImageUpload = (
     }
 
     if (validExtensions.includes(fileExtension) && fileSize <= 10) {
-      console.log('here');
       addUrl(key ?? 'https://storage.googleapis.com', file);
     } else {
       setErrorInvalidImage(true);

--- a/src/components/profile/widgets/util.tsx
+++ b/src/components/profile/widgets/util.tsx
@@ -188,7 +188,8 @@ export function normalizeUrl(url: string): string | undefined {
 export const handleImageUpload = (
   e: React.ChangeEvent<HTMLInputElement>,
   addUrl: (key: string, image: File) => void,
-  setErrorInvalidImage: Dispatch<SetStateAction<boolean>>
+  setErrorInvalidImage: Dispatch<SetStateAction<boolean>>,
+  key?: string
 ) => {
   const file = e.target.files ? e.target.files[0] : undefined;
   if (file) {
@@ -203,7 +204,8 @@ export const handleImageUpload = (
     }
 
     if (validExtensions.includes(fileExtension) && fileSize <= 10) {
-      addUrl('https://storage.googleapis.com', file);
+      console.log('here');
+      addUrl(key ?? 'https://storage.googleapis.com', file);
     } else {
       setErrorInvalidImage(true);
     }

--- a/src/components/profile/widgets/util.tsx
+++ b/src/components/profile/widgets/util.tsx
@@ -182,31 +182,19 @@ export function normalizeUrl(url: string): string | undefined {
   return undefined;
 }
 
-/**
- * Handle the image uploading process to Google Storage
- */
-export const handleImageUpload = (
-  e: React.ChangeEvent<HTMLInputElement>,
-  addUrl: (key: string, image: File) => void,
-  setErrorInvalidImage: Dispatch<SetStateAction<boolean>>,
-  key?: string
-) => {
-  const file = e.target.files ? e.target.files[0] : undefined;
+export const checkFileValid = (file: File) => {
   if (file) {
     const validExtensions = ['jpg', 'jpeg', 'png', 'gif', 'svg'];
     const fileSize = file.size / 1024 / 1024; // in MB
     const fileExtension = file.name.split('.').pop()?.toLowerCase();
-
     if (!fileExtension) {
-      // This condition is hit if there is no file extension
-      setErrorInvalidImage(true);
-      return;
+      return false;
     }
-
     if (validExtensions.includes(fileExtension) && fileSize <= 10) {
-      addUrl(key ?? 'https://storage.googleapis.com', file);
+      return true;
     } else {
-      setErrorInvalidImage(true);
+      return false;
     }
   }
+  return false;
 };

--- a/src/components/profile/widgets/widget-link.tsx
+++ b/src/components/profile/widgets/widget-link.tsx
@@ -49,7 +49,6 @@ export const LinkWidget: React.FC<LinkWidgetProps> = ({
                 identifier={identifier}
                 addImage={addImage}
                 removeImage={removeImage}
-                className='absolute left-1/2 top-0 z-20 flex -translate-x-1/2 -translate-y-1/2 transform items-center opacity-0 transition-opacity group-hover:opacity-100'
               />
             )}
             <div className='flex h-full flex-grow overflow-hidden'>
@@ -74,7 +73,6 @@ export const LinkWidget: React.FC<LinkWidgetProps> = ({
                 identifier={identifier}
                 addImage={addImage}
                 removeImage={removeImage}
-                className='absolute left-1/2 top-0 z-20 flex -translate-x-1/2 -translate-y-1/2 transform items-center opacity-0 transition-opacity group-hover:opacity-100'
               />
             )}
             <div className='flex h-full flex-grow overflow-hidden'>
@@ -94,13 +92,12 @@ export const LinkWidget: React.FC<LinkWidgetProps> = ({
             <div className='relative ml-auto w-2/3'>
               {showControls && (
                 <ModifyImageControls
-                  hasImage={heroImageUrl ? true : false}
+                  hasImage={!!heroImageUrl}
                   restoreImage={restoreImage}
                   setErrorInvalidImage={setErrorInvalidImage}
                   identifier={identifier}
                   addImage={addImage}
                   removeImage={removeImage}
-                  className='absolute left-1/2 top-0 z-20 flex -translate-x-1/2 -translate-y-1/2 transform items-center opacity-0 transition-opacity group-hover:opacity-100'
                 />
               )}
               <BannerImage src={heroImageUrl} />
@@ -124,7 +121,6 @@ export const LinkWidget: React.FC<LinkWidgetProps> = ({
                 identifier={identifier}
                 addImage={addImage}
                 removeImage={removeImage}
-                className='absolute left-1/2 top-0 z-20 flex -translate-x-1/2 -translate-y-1/2 transform items-center opacity-0 transition-opacity group-hover:opacity-100'
               />
             )}
             <BannerImage src={heroImageUrl} />

--- a/src/components/profile/widgets/widget-linkedin-profile.tsx
+++ b/src/components/profile/widgets/widget-linkedin-profile.tsx
@@ -123,7 +123,6 @@ export const LinkedInProfileWidget: React.FC<LinkedInProfileWidgetProps> = ({
                 identifier={identifier}
                 addImage={addImage}
                 removeImage={removeImage}
-                className='absolute left-1/2 top-0 z-20 flex -translate-x-1/2 -translate-y-1/2 transform items-center opacity-0 transition-opacity group-hover:opacity-100'
               />
             )}
             <BannerImage src={bannerImage} />

--- a/src/components/profile/widgets/widget-linkedin-profile.tsx
+++ b/src/components/profile/widgets/widget-linkedin-profile.tsx
@@ -90,18 +90,20 @@ export const LinkedInProfileWidget: React.FC<LinkedInProfileWidgetProps> = ({
             <WidgetIcon type='LinkedInProfile' className='mb-0' />
             <Title>{name}</Title>
           </WidgetHeader>
-          <div className='relative ml-auto w-3/5'>
-            {showControls && (
-              <ModifyImageControls
-                hasImage={!!bannerImage}
-                restoreImage={restoreImage}
-                setErrorInvalidImage={setErrorInvalidImage}
-                identifier={identifier}
-                addImage={addImage}
-                removeImage={removeImage}
-              />
-            )}
-            <BannerImage src={bannerImage} />
+          <div className='flex h-full flex-row justify-end gap-3'>
+            <div className='relative ml-auto w-2/3'>
+              {showControls && (
+                <ModifyImageControls
+                  hasImage={!!bannerImage}
+                  restoreImage={restoreImage}
+                  setErrorInvalidImage={setErrorInvalidImage}
+                  identifier={identifier}
+                  addImage={addImage}
+                  removeImage={removeImage}
+                />
+              )}
+              <BannerImage src={bannerImage} />
+            </div>
           </div>
         </WidgetLayout>
       );

--- a/src/hooks/profile/useLayoutManagement.ts
+++ b/src/hooks/profile/useLayoutManagement.ts
@@ -60,6 +60,7 @@ export const useLayoutManagement = ({ userId, editMode }: WidgetGridProps) => {
 
   const handleLayoutChange = useCallback(
     (newLayout: WidgetLayoutItem[]) => {
+      console.log('handleLayout called', newLayout, layout);
       const updatedLayout = newLayout.map((layoutItem) => {
         const existingItem = layout.find((item) => item.i === layoutItem.i);
         return existingItem ? { ...existingItem, ...layoutItem } : layoutItem;
@@ -72,6 +73,7 @@ export const useLayoutManagement = ({ userId, editMode }: WidgetGridProps) => {
   /** Triggered automatically when layout is changed, updates backend according to layout changes */
   const persistWidgetsLayoutOnChange = useCallback(
     (items?: WidgetLayoutItem[], key?: string) => {
+      console.log('persistLayout called');
       const itemsToUse = items && items.length > 0 ? items : layout;
       if (itemsToUse.length > 0 && editMode) {
         const payload: UpdateWidgetsBulkDto[] = itemsToUse.map((item) => {

--- a/src/hooks/profile/useLayoutManagement.ts
+++ b/src/hooks/profile/useLayoutManagement.ts
@@ -60,7 +60,6 @@ export const useLayoutManagement = ({ userId, editMode }: WidgetGridProps) => {
 
   const handleLayoutChange = useCallback(
     (newLayout: WidgetLayoutItem[]) => {
-      console.log('handleLayout called', newLayout, layout);
       const updatedLayout = newLayout.map((layoutItem) => {
         const existingItem = layout.find((item) => item.i === layoutItem.i);
         return existingItem ? { ...existingItem, ...layoutItem } : layoutItem;
@@ -73,7 +72,6 @@ export const useLayoutManagement = ({ userId, editMode }: WidgetGridProps) => {
   /** Triggered automatically when layout is changed, updates backend according to layout changes */
   const persistWidgetsLayoutOnChange = useCallback(
     (items?: WidgetLayoutItem[], key?: string) => {
-      console.log('persistLayout called');
       const itemsToUse = items && items.length > 0 ? items : layout;
       if (itemsToUse.length > 0 && editMode) {
         const payload: UpdateWidgetsBulkDto[] = itemsToUse.map((item) => {

--- a/src/hooks/profile/useWidgetManagement.ts
+++ b/src/hooks/profile/useWidgetManagement.ts
@@ -145,9 +145,12 @@ export const useWidgetManagement = ({
   /** Handles the replacement of display images for widgets */
   const handleNewImageAdd = useCallback(
     async (key: string, image: File) => {
+      console.log('function', key);
       let widgetUrl = '';
       try {
         const existingItem = layout.find((item) => item.i === key);
+
+        console.log(existingItem, image);
 
         if (existingItem && image && image !== undefined) {
           const fileExtension = image.name.split('.').pop()?.toLowerCase();
@@ -223,13 +226,14 @@ export const useWidgetManagement = ({
             key: existingItem.i,
             content: existingItem.content,
           });
-          setLayout((prevLayout) =>
-            prevLayout.map((item) =>
+          handleLayoutChange(
+            layout.map((item) =>
               item.i === existingItem.i
                 ? { ...item, content: existingItem.content }
                 : item
             )
           );
+          console.log('here');
         }
       } catch (error) {
         const message =
@@ -239,7 +243,12 @@ export const useWidgetManagement = ({
         });
       }
     },
-    [layout, uploadWidgetsImageAsync, updateWidgetContentAsync, setLayout]
+    [
+      layout,
+      uploadWidgetsImageAsync,
+      updateWidgetContentAsync,
+      handleLayoutChange,
+    ]
   );
 
   const handleRestoreImage = useCallback(

--- a/src/hooks/profile/useWidgetManagement.ts
+++ b/src/hooks/profile/useWidgetManagement.ts
@@ -319,6 +319,14 @@ export const useWidgetManagement = ({
             content: existingItem.content,
           });
 
+          handleLayoutChange(
+            layout.map((item) =>
+              item.i === existingItem.i
+                ? { ...item, content: existingItem.content }
+                : item
+            )
+          );
+
           // and if that site doesn't have an image, hold off on doing anything and inform the user.
         } else {
           toast(`It looks like this site has no image for this URL`, {
@@ -333,7 +341,12 @@ export const useWidgetManagement = ({
         });
       }
     },
-    [layout, restoreWidgetImageAsync, updateWidgetContentAsync]
+    [
+      handleLayoutChange,
+      layout,
+      restoreWidgetImageAsync,
+      updateWidgetContentAsync,
+    ]
   );
 
   /** Handles the replacement of display images for Link and Photo Widgets */
@@ -431,6 +444,7 @@ export const useWidgetManagement = ({
     [layout, updateWidgetContentAsync]
   );
 
+  /** Changes the redirectURL of a given widget (specified by the key) */
   const handleWidgetEditLink = useCallback(
     async (key: string, url: string) => {
       try {

--- a/src/hooks/profile/useWidgetManagement.ts
+++ b/src/hooks/profile/useWidgetManagement.ts
@@ -145,12 +145,9 @@ export const useWidgetManagement = ({
   /** Handles the replacement of display images for widgets */
   const handleNewImageAdd = useCallback(
     async (key: string, image: File) => {
-      console.log('function', key);
       let widgetUrl = '';
       try {
         const existingItem = layout.find((item) => item.i === key);
-
-        console.log(existingItem, image);
 
         if (existingItem && image && image !== undefined) {
           const fileExtension = image.name.split('.').pop()?.toLowerCase();
@@ -233,7 +230,6 @@ export const useWidgetManagement = ({
                 : item
             )
           );
-          console.log('here');
         }
       } catch (error) {
         const message =


### PR DESCRIPTION
# [SRBT-358] Widget replace and restore images

Also addresses SRBT 359

**Changes**

- You shouldn't need to refresh the page to see the widget images get replaced and/or restored
- LinkedIn Widget stylings got refactored so you can visually see the changes working
- Restore Image Icon was sized up

# Screenshots

Screenshots/videos of the changes made (if any, otherwise delete this section)

https://github.com/user-attachments/assets/08a827a6-aff1-4677-80cd-623dea833e4a

