### PR TITLE
[SRBT-371] User can only edit section titles when signed in

### DIFF
--- a/src/components/profile/widgets/widget-section.tsx
+++ b/src/components/profile/widgets/widget-section.tsx
@@ -5,15 +5,18 @@ import { cn } from '@/lib/utils';
 
 interface SectionTitleWidgetProps {
   title: string;
+  editMode: boolean;
   updateTitle: (title: string) => void;
 }
 
 export const SectionTitleWidget: React.FC<SectionTitleWidgetProps> = ({
   title,
+  editMode,
   updateTitle,
 }) => {
   const [editableTitle, setEditableTitle] = useState(title);
   const [isEditing, setIsEditing] = useState(false);
+  console.log('editMode', editMode);
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setEditableTitle(e.target.value);
@@ -31,9 +34,11 @@ export const SectionTitleWidget: React.FC<SectionTitleWidgetProps> = ({
     <div
       className={cn(
         `my-2 flex h-full w-full items-center rounded-3xl transition-colors duration-300`,
-        isEditing ? 'bg-white' : 'hover:bg-white'
+        isEditing ? 'bg-white' : editMode ? 'hover:bg-white' : ''
       )}
-      onClick={() => setIsEditing(true)} // Enable editing on click
+      onClick={() => {
+        if (editMode) setIsEditing(true);
+      }} // Enable editing on click if user is signed-in
     >
       {isEditing ? (
         <Input
@@ -45,12 +50,14 @@ export const SectionTitleWidget: React.FC<SectionTitleWidgetProps> = ({
           autoFocus
           className='ml-1 text-3xl font-semibold'
           variant='noBorderOrRing'
+          disabled={!editMode}
         />
       ) : (
         <div
           className={cn(
-            `ml-2 rounded-2xl px-2 py-2 text-3xl font-semibold hover:bg-[#D9D9D9]`,
-            !editableTitle ? 'text-muted-foreground' : 'text-[#344054]'
+            `ml-2 rounded-2xl px-2 py-2 text-3xl font-semibold`,
+            !editableTitle ? 'text-muted-foreground' : 'text-[#344054]',
+            editMode ? 'hover:bg-[#D9D9D9]' : ''
           )}
         >
           {editableTitle || 'Add a Title'}

--- a/src/components/profile/widgets/widget.tsx
+++ b/src/components/profile/widgets/widget.tsx
@@ -366,6 +366,7 @@ export const Widget: React.FC<WidgetProps> = ({
         setWidgetContent(
           <SectionTitleWidget
             title={(content as SectionTitleWidgetContentType).title}
+            editMode={showControls}
             updateTitle={updateTitle}
           />
         );


### PR DESCRIPTION
# [SRBT-371] User can only edit section titles when signed in

**Changes**

- I've added additional prop (`editMode`) to section titles widgets, similar to what the other widget types have, to disable a user from editing the text of a section widget if they're aren't authorized to do so.

# Screenshots


https://github.com/user-attachments/assets/aa27647c-29fc-453d-887e-72c632600d41

