### PR TITLE
[SRBT-372] Fix Layout C and D for Medium Widgets

### DIFF
--- a/src/components/profile/widgets/widget-medium.tsx
+++ b/src/components/profile/widgets/widget-medium.tsx
@@ -88,7 +88,6 @@ export const MediumWidget: React.FC<MediumWidgetProps> = ({
         <div className='flex h-full flex-row gap-2'>
           <div className='w-2/5'>
             <WidgetIcon type='Medium' />
-            <WidgetIcon type='Medium' />
             <div className='text-sm font-semibold'>{content.title}</div>
             <div className='text-xs text-gray-500'>{content.host}</div>
           </div>

--- a/src/components/profile/widgets/widget-medium.tsx
+++ b/src/components/profile/widgets/widget-medium.tsx
@@ -115,14 +115,18 @@ export const MediumWidget: React.FC<MediumWidgetProps> = ({
             <div className='text-sm font-semibold'>{content.title}</div>
             <div className='text-xs text-gray-500'>{content.host}</div>
           </div>
-          <div className='relative h-full w-full overflow-hidden rounded-xl'>
-            <img
-              src={content.image}
-              alt='Medium content'
-              className='h-full w-full object-cover'
-              style={{ objectFit: 'cover' }}
-            />
-            <ImageOverlay />
+          <div className='relative h-full w-full'>
+            {showControls && (
+              <ModifyImageControls
+                hasImage={!!content.image}
+                restoreImage={restoreImage}
+                setErrorInvalidImage={setErrorInvalidImage}
+                identifier={identifier}
+                addImage={addImage}
+                removeImage={removeImage}
+              />
+            )}
+            <BannerImage src={content.image} />
           </div>
         </div>
       );


### PR DESCRIPTION
# [SRBT-372] Fix Layout C and D for Medium Widgets

**Changes**

- In layout C, there was an extra medium icon. It is now removed.
- In layout D, the modify widget bar above the image was clipped. It's now fully visible.

# Screenshots

![Screenshot 2024-12-16 at 9 23 37 AM](https://github.com/user-attachments/assets/abb92fa0-7869-4724-9178-64516d68fda1)
![Screenshot 2024-12-16 at 9 34 25 AM](https://github.com/user-attachments/assets/fb2649ad-d9cb-49d8-b089-1644bb8ab1ba)
