### PR TITLE
 [SRBT-375] Add loading state if widget is being modified

### DIFF
--- a/src/components/profile/widgets/resize-widget.tsx
+++ b/src/components/profile/widgets/resize-widget.tsx
@@ -108,28 +108,52 @@ export const ResizeWidget: React.FC<ResizeWidgetProps> = ({
       )}
       onMouseLeave={handleMouseLeave} // Close popover on mouse leave
     >
-      <button className={btnClass} onClick={(e) => onResizeClick(e, 'A')}>
+      <button
+        className={btnClass}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          onResizeClick(e, 'A');
+        }}
+      >
         <Square
           size={16}
           fill={currentSize === 'A' && !activeWidget ? '#fff' : 'transparent'}
           strokeWidth={2.5}
         />
       </button>
-      <div className={btnClass} onClick={(e) => onResizeClick(e, 'B')}>
+      <div
+        className={btnClass}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          onResizeClick(e, 'B');
+        }}
+      >
         <Square
           size={22}
           fill={currentSize === 'B' && !activeWidget ? '#fff' : 'transparent'}
           strokeWidth={2.5}
         />
       </div>
-      <div className={btnClass} onClick={(e) => onResizeClick(e, 'C')}>
+      <div
+        className={btnClass}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          onResizeClick(e, 'C');
+        }}
+      >
         <RectangleHorizontal
           size={16}
           fill={currentSize === 'C' && !activeWidget ? '#fff' : 'transparent'}
           strokeWidth={2.5}
         />
       </div>
-      <div className={btnClass} onClick={(e) => onResizeClick(e, 'D')}>
+      <div
+        className={btnClass}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          onResizeClick(e, 'D');
+        }}
+      >
         <RectangleVertical
           size={16}
           fill={currentSize === 'D' && !activeWidget ? '#fff' : 'transparent'}

--- a/src/components/profile/widgets/resize-widget.tsx
+++ b/src/components/profile/widgets/resize-widget.tsx
@@ -110,8 +110,7 @@ export const ResizeWidget: React.FC<ResizeWidgetProps> = ({
     >
       <button
         className={btnClass}
-        onMouseDown={(e) => {
-          e.stopPropagation();
+        onClick={(e) => {
           onResizeClick(e, 'A');
         }}
       >
@@ -123,8 +122,7 @@ export const ResizeWidget: React.FC<ResizeWidgetProps> = ({
       </button>
       <div
         className={btnClass}
-        onMouseDown={(e) => {
-          e.stopPropagation();
+        onClick={(e) => {
           onResizeClick(e, 'B');
         }}
       >
@@ -136,8 +134,7 @@ export const ResizeWidget: React.FC<ResizeWidgetProps> = ({
       </div>
       <div
         className={btnClass}
-        onMouseDown={(e) => {
-          e.stopPropagation();
+        onClick={(e) => {
           onResizeClick(e, 'C');
         }}
       >
@@ -150,7 +147,6 @@ export const ResizeWidget: React.FC<ResizeWidgetProps> = ({
       <div
         className={btnClass}
         onMouseDown={(e) => {
-          e.stopPropagation();
           onResizeClick(e, 'D');
         }}
       >

--- a/src/components/profile/widgets/widget-grid.tsx
+++ b/src/components/profile/widgets/widget-grid.tsx
@@ -201,7 +201,7 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
                         h={item.h}
                         type={item.type}
                         showControls={editMode}
-                        handleResize={() => handleWidgetResize}
+                        handleResize={handleWidgetResize}
                         handleRemove={(key) => handleWidgetRemove(key)}
                         handleEditLink={() => handleWidgetEditLink}
                         handleRestoreImage={handleRestoreImage}

--- a/src/components/profile/widgets/widget-grid.tsx
+++ b/src/components/profile/widgets/widget-grid.tsx
@@ -43,10 +43,11 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
   const {
     layout,
     setLayout,
+    handleLayoutChange,
+    persistWidgetsLayoutOnChange,
     cols,
     animationStyles,
     widgetRefs,
-    handleLayoutChange,
     handleWidgetDropStop,
     handleWidgetResize,
     isUserWidgetPending,
@@ -73,7 +74,7 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
     editMode,
     layout,
     setLayout,
-    handleLayoutChange,
+    persistWidgetsLayoutOnChange,
     cols,
   });
 
@@ -200,9 +201,9 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
                         h={item.h}
                         type={item.type}
                         showControls={editMode}
-                        handleResize={handleWidgetResize}
-                        handleRemove={handleWidgetRemove}
-                        handleEditLink={handleWidgetEditLink}
+                        handleResize={() => handleWidgetResize}
+                        handleRemove={(key) => handleWidgetRemove(key)}
+                        handleEditLink={() => handleWidgetEditLink}
                         handleRestoreImage={handleRestoreImage}
                         content={item.content}
                         size={item.size}
@@ -298,9 +299,9 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
                   h={item.h}
                   type={item.type}
                   showControls={editMode}
-                  handleResize={handleWidgetResize}
-                  handleRemove={handleWidgetRemove}
-                  handleEditLink={handleWidgetEditLink}
+                  handleResize={() => handleWidgetResize}
+                  handleRemove={() => handleWidgetRemove}
+                  handleEditLink={() => handleWidgetEditLink}
                   handleRestoreImage={handleRestoreImage}
                   content={item.content}
                   size={item.size}

--- a/src/components/profile/widgets/widget-grid.tsx
+++ b/src/components/profile/widgets/widget-grid.tsx
@@ -56,6 +56,7 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
     errorInvalidImage,
     setErrorInvalidImage,
     addingWidget,
+    modifyingWidget,
     handleWidgetRemove,
     handleWidgetAdd,
     handleFileDrop,
@@ -218,7 +219,7 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
                         setActiveWidget={setActiveWidget}
                         addImage={handleNewImageAdd}
                         removeImage={handleImageRemoval}
-                        loading={addingWidget}
+                        loading={modifyingWidget}
                         setErrorInvalidImage={setErrorInvalidImage}
                       />
                     </motion.div>
@@ -315,7 +316,7 @@ export const WidgetGrid: React.FC<WidgetGridProps> = ({
                   setActiveWidget={setActiveWidget}
                   addImage={handleNewImageAdd}
                   removeImage={handleImageRemoval}
-                  loading={addingWidget}
+                  loading={modifyingWidget}
                   handleTitleUpdate={handleSectionTitleUpdate}
                   setErrorInvalidImage={setErrorInvalidImage}
                 />

--- a/src/components/profile/widgets/widget-section.tsx
+++ b/src/components/profile/widgets/widget-section.tsx
@@ -16,7 +16,6 @@ export const SectionTitleWidget: React.FC<SectionTitleWidgetProps> = ({
 }) => {
   const [editableTitle, setEditableTitle] = useState(title);
   const [isEditing, setIsEditing] = useState(false);
-  console.log('editMode', editMode);
 
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setEditableTitle(e.target.value);

--- a/src/components/profile/widgets/widget.tsx
+++ b/src/components/profile/widgets/widget.tsx
@@ -51,7 +51,7 @@ interface WidgetProps extends BaseWidgetProps {
   w: number;
   h: number;
   content?: WidgetContentType;
-  loading?: boolean;
+  loading: string | null;
   draggedRef: React.MutableRefObject<boolean>;
   activeWidget: string | null;
   widgetDimensions: {
@@ -417,7 +417,7 @@ export const Widget: React.FC<WidgetProps> = ({
         key={identifier}
         onClick={!showControls ? onWidgetClick : undefined} // Don't redirect if editing dashboard, similar to Bento
       >
-        {loading ? (
+        {loading === identifier ? (
           <Skeleton
             className={cn(
               'size-full rounded-xl',

--- a/src/components/profile/widgets/widget.tsx
+++ b/src/components/profile/widgets/widget.tsx
@@ -415,7 +415,7 @@ export const Widget: React.FC<WidgetProps> = ({
         )}
         id={identifier}
         key={identifier}
-        onClick={!showControls ? onWidgetClick : undefined} // Don't redirect if editing dashboard, similar to Bento
+        onMouseDown={!showControls ? onWidgetClick : undefined} // Don't redirect if editing dashboard, similar to Bento
       >
         {loading === identifier ? (
           <Skeleton
@@ -461,6 +461,7 @@ export const Widget: React.FC<WidgetProps> = ({
                 variant='outline'
                 size='icon'
                 className='rounded-full border-gray-800 bg-gray-800 text-white hover:bg-gray-800 hover:text-white'
+                // https://github.com/react-grid-layout/react-grid-layout/issues/166
                 onMouseDown={(e) => {
                   e.stopPropagation();
                   handleRemove(identifier);

--- a/src/components/profile/widgets/widget.tsx
+++ b/src/components/profile/widgets/widget.tsx
@@ -461,7 +461,7 @@ export const Widget: React.FC<WidgetProps> = ({
                 variant='outline'
                 size='icon'
                 className='rounded-full border-gray-800 bg-gray-800 text-white hover:bg-gray-800 hover:text-white'
-                onClick={(e) => {
+                onMouseDown={(e) => {
                   e.stopPropagation();
                   handleRemove(identifier);
                 }}

--- a/src/hooks/profile/useLayoutManagement.ts
+++ b/src/hooks/profile/useLayoutManagement.ts
@@ -60,7 +60,6 @@ export const useLayoutManagement = ({ userId, editMode }: WidgetGridProps) => {
 
   const handleLayoutChange = useCallback(
     (newLayout: WidgetLayoutItem[]) => {
-      console.log('handlechange', newLayout, layout);
       const updatedLayout = newLayout.map((layoutItem) => {
         const existingItem = layout.find((item) => item.i === layoutItem.i);
         return existingItem ? { ...existingItem, ...layoutItem } : layoutItem;
@@ -73,8 +72,7 @@ export const useLayoutManagement = ({ userId, editMode }: WidgetGridProps) => {
   /** Triggered automatically when layout is changed, updates backend according to layout changes */
   const persistWidgetsLayoutOnChange = useCallback(
     (items?: WidgetLayoutItem[], key?: string) => {
-      console.log('persist', items);
-      const itemsToUse = items && items.length > 0 ? items : [];
+      const itemsToUse = items && items.length > 0 ? items : layout;
       if (itemsToUse.length > 0 && editMode) {
         const payload: UpdateWidgetsBulkDto[] = itemsToUse.map((item) => {
           if (key && item.i === key) {
@@ -94,7 +92,7 @@ export const useLayoutManagement = ({ userId, editMode }: WidgetGridProps) => {
         updateWidgetsBulk(payload);
       }
     },
-    [editMode, updateWidgetsBulk]
+    [layout, editMode, updateWidgetsBulk]
   );
 
   const handleWidgetDropStop = useCallback(

--- a/src/hooks/profile/useLayoutManagement.ts
+++ b/src/hooks/profile/useLayoutManagement.ts
@@ -60,6 +60,7 @@ export const useLayoutManagement = ({ userId, editMode }: WidgetGridProps) => {
 
   const handleLayoutChange = useCallback(
     (newLayout: WidgetLayoutItem[]) => {
+      console.log('handlechange', newLayout, layout);
       const updatedLayout = newLayout.map((layoutItem) => {
         const existingItem = layout.find((item) => item.i === layoutItem.i);
         return existingItem ? { ...existingItem, ...layoutItem } : layoutItem;
@@ -72,7 +73,8 @@ export const useLayoutManagement = ({ userId, editMode }: WidgetGridProps) => {
   /** Triggered automatically when layout is changed, updates backend according to layout changes */
   const persistWidgetsLayoutOnChange = useCallback(
     (items?: WidgetLayoutItem[], key?: string) => {
-      const itemsToUse = items && items.length > 0 ? items : layout;
+      console.log('persist', items);
+      const itemsToUse = items && items.length > 0 ? items : [];
       if (itemsToUse.length > 0 && editMode) {
         const payload: UpdateWidgetsBulkDto[] = itemsToUse.map((item) => {
           if (key && item.i === key) {
@@ -92,7 +94,7 @@ export const useLayoutManagement = ({ userId, editMode }: WidgetGridProps) => {
         updateWidgetsBulk(payload);
       }
     },
-    [layout, editMode, updateWidgetsBulk]
+    [editMode, updateWidgetsBulk]
   );
 
   const handleWidgetDropStop = useCallback(
@@ -243,11 +245,12 @@ export const useLayoutManagement = ({ userId, editMode }: WidgetGridProps) => {
   return {
     layout,
     setLayout,
+    handleLayoutChange,
+    persistWidgetsLayoutOnChange,
     cols,
     animationStyles,
     widgetRefs,
     currentBreakpoint,
-    handleLayoutChange,
     handleWidgetDropStop,
     handleWidgetResize,
     isUserWidgetPending,

--- a/src/hooks/profile/useWidgetManagement.ts
+++ b/src/hooks/profile/useWidgetManagement.ts
@@ -62,7 +62,6 @@ export const useWidgetManagement = ({
 
   const handleWidgetRemove = useCallback(
     async (key: string) => {
-      console.log('here');
       if (removingWidget) return;
       try {
         setRemovingWidget(true);

--- a/src/hooks/profile/useWidgetManagement.ts
+++ b/src/hooks/profile/useWidgetManagement.ts
@@ -365,9 +365,11 @@ export const useWidgetManagement = ({
   const handleImageRemoval = useCallback(
     async (key: string) => {
       try {
+        if (modifyingWidget) return;
         const existingItem = layout.find((item) => item.i === key);
 
         if (existingItem) {
+          setModifyingWidget(key);
           switch (existingItem.type) {
             case 'Link':
               (existingItem.content as LinkWidgetContentType).heroImageUrl =
@@ -418,6 +420,7 @@ export const useWidgetManagement = ({
             key: existingItem.i,
             content: existingItem.content,
           });
+          setModifyingWidget(null);
         }
       } catch (error) {
         const message =


### PR DESCRIPTION
# [SRBT-375] Add loading state if widget is being modified

Due to the changes explained below, this PR also addresses [SRBT-345](https://linear.app/mysorbet/issue/SRBT-345/look-into-dual-toast-error-for-section-titles).

**Changes**

* Refactored the loading states of the profile page to instead only put a widget that's being directly modified (i.e. new image upload, restoring image, etc.) into a loading state.
* Notably, I refactored several of the `onClick` functions in `widget.tsx` to resolve some of the deeper issues with race conditions happening on the profile page, like so:
  * old way: `onClick={(e) => {
                  handleRemove(identifier);
                }}`
  * new way: `onMouseDown={(e) => {
                  e.stopPropagation();
                  handleRemove(identifier);
                }}`
  * When `onClick` is used, it's technically consider a "dragging" motion by [react-grid-layout](https://github.com/react-grid-layout/react-grid-layout/issues/166), and thus `handleLayout` was getting triggered and subsequently `persistWidgetsLayoutOnChange` due to the change to `layout`. So there was two outgoing calls to the bulk-update endpoint in the following order: one where it thought the widget is just getting moved in the grid, and one where it was considered deleted (which is why it was inconsistent on when failures happen).

# Screenshots

Screenshots/videos of the changes made (if any, otherwise delete this section)
