### PR TITLE
[SRBT-355] Instagram widget image replacement and restoring

### DIFF
--- a/src/api/widgets.ts
+++ b/src/api/widgets.ts
@@ -106,18 +106,37 @@ export const updateWidget = async (
 export const restoreWidgetImage = async (
   widgetId: string,
   type: WidgetType,
-  redirectUrl: string,
-  content: WidgetContentType
+  redirectUrl: string
 ): Promise<string | undefined> => {
   try {
     const payload: Partial<WidgetDto> = {
       id: widgetId,
       type: type,
       redirectUrl: redirectUrl,
-      content: content,
     };
     const response = await axios.post(
       `${env.NEXT_PUBLIC_SORBET_API_URL}/widgets/restore-image`,
+      payload,
+      await withAuthHeader()
+    );
+    return response.data;
+  } catch (error) {
+    catchAndRethrowWidgetError(error, `Failed to update widgets in bulk`);
+  }
+};
+
+export const restoreInstagramWidget = async (
+  widgetId: string,
+  redirectUrl: string
+): Promise<{ message: string; description: string } | undefined> => {
+  try {
+    const payload: Partial<WidgetDto> = {
+      id: widgetId,
+      redirectUrl: redirectUrl,
+    };
+    console.log('restore image', payload);
+    const response = await axios.post(
+      `${env.NEXT_PUBLIC_SORBET_API_URL}/widgets/restore-instagram-widget`,
       payload,
       await withAuthHeader()
     );
@@ -160,6 +179,7 @@ export const updateWidgetContent = async (
   };
 
   try {
+    console.log(payload);
     const response = await axios.patch(
       `${env.NEXT_PUBLIC_SORBET_API_URL}/widgets/${key}`,
       payload,

--- a/src/api/widgets.ts
+++ b/src/api/widgets.ts
@@ -134,7 +134,6 @@ export const restoreInstagramWidget = async (
       id: widgetId,
       redirectUrl: redirectUrl,
     };
-    console.log('restore image', payload);
     const response = await axios.post(
       `${env.NEXT_PUBLIC_SORBET_API_URL}/widgets/restore-instagram-widget`,
       payload,
@@ -179,7 +178,6 @@ export const updateWidgetContent = async (
   };
 
   try {
-    console.log(payload);
     const response = await axios.patch(
       `${env.NEXT_PUBLIC_SORBET_API_URL}/widgets/${key}`,
       payload,

--- a/src/components/profile/widgets/banner-image.tsx
+++ b/src/components/profile/widgets/banner-image.tsx
@@ -26,7 +26,7 @@ export const BannerImage: React.FC<{ src?: string; className?: string }> = ({
           <ImageOverlay />
         </>
       ) : (
-        <span className='text-sm font-semibold text-[#344054]'>
+        <span className='text-muted-foreground text-sm font-semibold'>
           Nothing to see here
         </span>
       )}

--- a/src/components/profile/widgets/modify-image-controls.tsx
+++ b/src/components/profile/widgets/modify-image-controls.tsx
@@ -78,7 +78,7 @@ export const ModifyImageControls: React.FC<ModifyImageControlsProps> = ({
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger>
-                <div className={btnClass} onClick={restoreImage}>
+                <div className={btnClass} onMouseDown={restoreImage}>
                   <LinkedPictureIcon className='size-6 text-white' />
                 </div>
               </TooltipTrigger>
@@ -90,7 +90,7 @@ export const ModifyImageControls: React.FC<ModifyImageControlsProps> = ({
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger>
-                <div className={btnClass} onClick={handleImageRemove}>
+                <div className={btnClass} onMouseDown={handleImageRemove}>
                   <Trash2 size={22} />
                 </div>
               </TooltipTrigger>
@@ -103,7 +103,7 @@ export const ModifyImageControls: React.FC<ModifyImageControlsProps> = ({
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger>
-                <div className={btnClass} onClick={restoreImage}>
+                <div className={btnClass} onMouseDown={restoreImage}>
                   <LinkedPictureIcon className='size-6 text-white' />
                 </div>
               </TooltipTrigger>

--- a/src/components/profile/widgets/widget-behance.tsx
+++ b/src/components/profile/widgets/widget-behance.tsx
@@ -23,7 +23,7 @@ export const BehanceWidget: React.FC<BehanceWidgetProps> = ({
   let widgetLayout;
 
   const restoreImage = async () => {
-    await handleRestoreImage(identifier, 'Behance', redirectUrl ?? '', content); // Call the mutation with the image URL
+    await handleRestoreImage(identifier, 'Behance', redirectUrl ?? ''); // Call the mutation with the image URL
   };
 
   switch (size) {

--- a/src/components/profile/widgets/widget-dribbble.tsx
+++ b/src/components/profile/widgets/widget-dribbble.tsx
@@ -21,12 +21,7 @@ export const DribbbleWidget: React.FC<DribbbleWidgetProps> = ({
   handleRestoreImage,
 }) => {
   const restoreImage = async () => {
-    await handleRestoreImage(
-      identifier,
-      'Dribbble',
-      redirectUrl ?? '',
-      content
-    ); // Call the mutation with the image URL
+    await handleRestoreImage(identifier, 'Dribbble', redirectUrl ?? ''); // Call the mutation with the image URL
   };
 
   let widgetLayout;

--- a/src/components/profile/widgets/widget-github.tsx
+++ b/src/components/profile/widgets/widget-github.tsx
@@ -22,7 +22,7 @@ export const GithubWidget: React.FC<GithubWidgetProps> = ({
   let widgetLayout;
 
   const restoreImage = async () => {
-    await handleRestoreImage(identifier, 'Github', redirectUrl ?? '', content); // Call the mutation with the image URL
+    await handleRestoreImage(identifier, 'Github', redirectUrl ?? ''); // Call the mutation with the image URL
   };
 
   switch (size) {

--- a/src/components/profile/widgets/widget-instagram.tsx
+++ b/src/components/profile/widgets/widget-instagram.tsx
@@ -81,7 +81,9 @@ export const InstagramWidget: React.FC<InstagramWidgetProps> = ({
           <div className='relative flex-grow'>
             {showControls && (
               <ModifyImageControls
-                hasImage={content.replacementPicture ? true : false}
+                hasImage={
+                  content.replacementPicture || content.images ? true : false
+                }
                 restoreImage={restoreImage}
                 setErrorInvalidImage={setErrorInvalidImage}
                 identifier={identifier}
@@ -139,7 +141,9 @@ export const InstagramWidget: React.FC<InstagramWidgetProps> = ({
           <div className='relative h-full w-1/2 rounded-xl'>
             {showControls && (
               <ModifyImageControls
-                hasImage={content.replacementPicture ? true : false}
+                hasImage={
+                  content.replacementPicture || content.images ? true : false
+                }
                 restoreImage={restoreImage}
                 setErrorInvalidImage={setErrorInvalidImage}
                 identifier={identifier}
@@ -166,7 +170,9 @@ export const InstagramWidget: React.FC<InstagramWidgetProps> = ({
           <div className='relative mt-24 h-full w-full overflow-hidden rounded-xl'>
             {showControls && (
               <ModifyImageControls
-                hasImage={content.replacementPicture ? true : false}
+                hasImage={
+                  content.replacementPicture || content.images ? true : false
+                }
                 restoreImage={restoreImage}
                 setErrorInvalidImage={setErrorInvalidImage}
                 identifier={identifier}
@@ -202,27 +208,26 @@ const InstagramImageContent = ({
   heightClass,
   replacementPicture,
 }: InstagramImageContentProps) => {
+  // priority to display: images from the actual profile -> pictures the sorbet user uploaded -> placeholders
   return (
     <>
-      {isPrivate ? (
-        replacementPicture ? (
-          <>
-            <img
-              src={replacementPicture}
-              alt='Banner image from url'
-              className='absolute inset-0 h-full w-full rounded-xl object-cover'
-            />
-            <ImageOverlay />
-          </>
-        ) : (
-          <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-100 text-sm font-semibold'>
-            This account is private
-          </span>
-        )
-      ) : images.length > 0 ? (
+      {images.length > 0 ? (
         <div className={className}>
           <ImageGallery images={images} heightClass={heightClass} />
         </div>
+      ) : replacementPicture ? (
+        <>
+          <img
+            src={replacementPicture}
+            alt='Banner image from url'
+            className='absolute inset-0 h-full w-full rounded-xl object-cover'
+          />
+          <ImageOverlay />
+        </>
+      ) : isPrivate ? (
+        <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-100 text-sm font-semibold'>
+          This account is private
+        </span>
       ) : (
         <span className='text-muted-foreground flex h-full w-full items-center justify-center rounded-2xl bg-gray-100 text-sm font-semibold'>
           Nothing to see here

--- a/src/components/profile/widgets/widget-link.tsx
+++ b/src/components/profile/widgets/widget-link.tsx
@@ -29,7 +29,7 @@ export const LinkWidget: React.FC<LinkWidgetProps> = ({
   const { title, iconUrl, heroImageUrl } = content;
 
   const restoreImage = async () => {
-    await handleRestoreImage(identifier, 'Link', redirectUrl ?? '', content); // Call the mutation with the image URL
+    await handleRestoreImage(identifier, 'Link', redirectUrl ?? ''); // Call the mutation with the image URL
   };
 
   switch (size) {

--- a/src/components/profile/widgets/widget-linkedin-profile.tsx
+++ b/src/components/profile/widgets/widget-linkedin-profile.tsx
@@ -26,12 +26,7 @@ export const LinkedInProfileWidget: React.FC<LinkedInProfileWidgetProps> = ({
   const { name, bannerImage } = content;
 
   const restoreImage = async () => {
-    await handleRestoreImage(
-      identifier,
-      'LinkedInProfile',
-      redirectUrl ?? '',
-      content
-    ); // Call the mutation with the image URL
+    await handleRestoreImage(identifier, 'LinkedInProfile', redirectUrl ?? ''); // Call the mutation with the image URL
   };
 
   switch (size) {

--- a/src/components/profile/widgets/widget-medium.tsx
+++ b/src/components/profile/widgets/widget-medium.tsx
@@ -23,7 +23,7 @@ export const MediumWidget: React.FC<MediumWidgetProps> = ({
   let widgetLayout;
 
   const restoreImage = async () => {
-    await handleRestoreImage(identifier, 'Medium', redirectUrl ?? '', content); // Call the mutation with the image URL
+    await handleRestoreImage(identifier, 'Medium', redirectUrl ?? ''); // Call the mutation with the image URL
   };
 
   switch (size) {

--- a/src/components/profile/widgets/widget-soundcloud.tsx
+++ b/src/components/profile/widgets/widget-soundcloud.tsx
@@ -32,12 +32,7 @@ export const SoundcloudWidget: React.FC<SoundcloudWidgetProps> = ({
   );
 
   const restoreImage = async () => {
-    await handleRestoreImage(
-      identifier,
-      'SoundcloudSong',
-      redirectUrl ?? '',
-      content
-    ); // Call the mutation with the image URL
+    await handleRestoreImage(identifier, 'SoundcloudSong', redirectUrl ?? ''); // Call the mutation with the image URL
   };
 
   switch (size) {

--- a/src/components/profile/widgets/widget-substack.tsx
+++ b/src/components/profile/widgets/widget-substack.tsx
@@ -24,12 +24,7 @@ export const SubstackWidget: React.FC<SubstackWidgetProps> = ({
   let widgetLayout;
 
   const restoreImage = async () => {
-    await handleRestoreImage(
-      identifier,
-      'Substack',
-      redirectUrl ?? '',
-      content
-    ); // Call the mutation with the image URL
+    await handleRestoreImage(identifier, 'Substack', redirectUrl ?? ''); // Call the mutation with the image URL
   };
 
   const localHeader = (

--- a/src/components/profile/widgets/widget-twitter.tsx
+++ b/src/components/profile/widgets/widget-twitter.tsx
@@ -31,12 +31,7 @@ export const TwitterWidget: React.FC<TwitterWidgetProps> = ({
   const { handle, bio, bannerImage, profileImage } = content;
 
   const restoreImage = async () => {
-    await handleRestoreImage(
-      identifier,
-      'TwitterProfile',
-      redirectUrl ?? '',
-      content
-    ); // Call the mutation with the image URL
+    await handleRestoreImage(identifier, 'TwitterProfile', redirectUrl ?? ''); // Call the mutation with the image URL
   };
 
   switch (size) {

--- a/src/components/profile/widgets/widget-youtube.tsx
+++ b/src/components/profile/widgets/widget-youtube.tsx
@@ -31,7 +31,7 @@ export const YouTubeWidget: React.FC<YouTubeWidgetProps> = ({
   );
 
   const restoreImage = async () => {
-    await handleRestoreImage(identifier, 'Youtube', redirectUrl ?? '', content); // Call the mutation with the image URL
+    await handleRestoreImage(identifier, 'Youtube', redirectUrl ?? ''); // Call the mutation with the image URL
   };
 
   switch (size) {

--- a/src/components/profile/widgets/widget.tsx
+++ b/src/components/profile/widgets/widget.tsx
@@ -259,6 +259,13 @@ export const Widget: React.FC<WidgetProps> = ({
           <InstagramWidget
             content={content as InstagramWidgetContentType}
             size={widgetSize}
+            setErrorInvalidImage={setErrorInvalidImage}
+            identifier={identifier}
+            addImage={addImage}
+            removeImage={removeImage}
+            showControls={showControls}
+            redirectUrl={redirectUrl}
+            handleRestoreImage={handleRestoreImage}
           />
         );
         break;

--- a/src/hooks/profile/useWidgetManagement.ts
+++ b/src/hooks/profile/useWidgetManagement.ts
@@ -227,6 +227,7 @@ export const useWidgetManagement = ({
               (
                 existingItem.content as InstagramWidgetContentType
               ).replacementPicture = widgetUrl;
+              (existingItem.content as InstagramWidgetContentType).images = [];
               break;
             case 'LinkedInProfile':
               (
@@ -245,8 +246,6 @@ export const useWidgetManagement = ({
             const newLayout = [...prevLayout, existingItem];
             return newLayout;
           });
-
-          setModifyingWidget(null);
         }
       } catch (error) {
         const message =
@@ -254,6 +253,8 @@ export const useWidgetManagement = ({
         toast(`We couldn't update a widget`, {
           description: message,
         });
+      } finally {
+        setModifyingWidget(null);
       }
     },
     [
@@ -373,50 +374,12 @@ export const useWidgetManagement = ({
       layout,
       modifyingWidget,
       persistWidgetsLayoutOnChange,
+      restoreInstagramWidgetAsync,
       restoreWidgetImageAsync,
       setLayout,
       updateWidgetContentAsync,
     ]
   );
-
-  /**
-   * else if (
-          returnedImage !== undefined &&
-          typeof returnedImage !== 'string'
-        ) {
-
-        const { handle, images, isPrivate } = returnedImage;
-          if (
-            (existingItem.content as InstagramWidgetContentType).images ===
-              images &&
-            !isPrivate
-          ) {
-            toast(`Looks like there's no new posts for this profile`, {
-              description: `We won't change the pictures for now, but you can manually upload your own photos if you want.`,
-            });
-          } else if (isPrivate) {
-            toast(`This account is private`, {
-              description: `We can't fetch any photos from this account, but you can manually upload your own photos if you want.`,
-            });
-          } else {
-            (existingItem.content as InstagramWidgetContentType).handle =
-              handle;
-            (existingItem.content as InstagramWidgetContentType).images =
-              images;
-            (existingItem.content as InstagramWidgetContentType).isPrivate =
-              isPrivate;
-
-            await updateWidgetContentAsync({
-              key: existingItem.i,
-              content: existingItem.content,
-            });
-
-            setLayout((prevLayout) => {
-              const newLayout = [...prevLayout, existingItem];
-              persistWidgetsLayoutOnChange(newLayout);
-              return newLayout;
-            });
-   */
 
   /** Handles the replacement of display images for Link and Photo Widgets */
   const handleImageRemoval = useCallback(
@@ -479,10 +442,6 @@ export const useWidgetManagement = ({
             default:
               break;
           }
-          console.log({
-            key: existingItem.i,
-            content: existingItem.content,
-          });
           await updateWidgetContentAsync({
             key: existingItem.i,
             content: existingItem.content,

--- a/src/hooks/profile/useWidgetManagement.ts
+++ b/src/hooks/profile/useWidgetManagement.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-case-declarations */
 import { useCallback, useState } from 'react';
 import { Area } from 'react-easy-crop';
 import { toast } from 'sonner';
@@ -9,12 +10,14 @@ import {
   useUploadWidgetsImage,
 } from '@/hooks';
 import { useUpdateWidgetContent } from '@/hooks/profile/useUpdateWidgetContent';
+import { useRestoreInstagramWidget } from '@/hooks/widgets/useRestoreInstagramWidget';
 import { useRestoreWidgetImage } from '@/hooks/widgets/useRestoreWidgetImage';
 import { useUpdateWidgetLink } from '@/hooks/widgets/useUpdateWidgetLink';
 import {
   BehanceWidgetContentType,
   DribbbleWidgetContentType,
   GithubWidgetContentType,
+  InstagramWidgetContentType,
   LinkedInProfileWidgetContentType,
   LinkWidgetContentType,
   PhotoWidgetContentType,
@@ -22,7 +25,6 @@ import {
   SoundcloudTrackContentType,
   SubstackWidgetContentType,
   TwitterWidgetContentType,
-  WidgetContentType,
   WidgetDimensions,
   WidgetLayoutItem,
   WidgetType,
@@ -59,6 +61,8 @@ export const useWidgetManagement = ({
   const { mutateAsync: updateWidgetContentAsync } = useUpdateWidgetContent();
   const { mutateAsync: updateWidgetLinkAsync } = useUpdateWidgetLink();
   const { mutateAsync: restoreWidgetImageAsync } = useRestoreWidgetImage();
+  const { mutateAsync: restoreInstagramWidgetAsync } =
+    useRestoreInstagramWidget();
 
   const handleWidgetRemove = useCallback(
     async (key: string) => {
@@ -219,6 +223,11 @@ export const useWidgetManagement = ({
               (existingItem.content as DribbbleWidgetContentType).image =
                 widgetUrl;
               break;
+            case 'InstagramProfile':
+              (
+                existingItem.content as InstagramWidgetContentType
+              ).replacementPicture = widgetUrl;
+              break;
             case 'LinkedInProfile':
               (
                 existingItem.content as LinkedInProfileWidgetContentType
@@ -257,12 +266,7 @@ export const useWidgetManagement = ({
   );
 
   const handleRestoreImage = useCallback(
-    async (
-      key: string,
-      type: WidgetType,
-      redirectUrl: string,
-      content: WidgetContentType
-    ) => {
+    async (key: string, type: WidgetType, redirectUrl: string) => {
       try {
         if (modifyingWidget) return;
         const existingItem = layout.find((item) => item.i === key);
@@ -271,84 +275,98 @@ export const useWidgetManagement = ({
         }
 
         setModifyingWidget(key);
-        const returnedImage = await restoreWidgetImageAsync({
-          key,
-          type,
-          redirectUrl,
-          content,
-        });
-        // if image does exist, now you can update it
-        if (returnedImage !== undefined && returnedImage !== '') {
-          switch (existingItem.type) {
-            case 'Link':
-              (existingItem.content as LinkWidgetContentType).heroImageUrl =
-                returnedImage;
-              break;
-            case 'SoundcloudSong':
-              (existingItem.content as SoundcloudTrackContentType).artwork =
-                returnedImage;
-              break;
-            case 'Substack':
-              (existingItem.content as SubstackWidgetContentType).image =
-                returnedImage;
-              break;
-            case 'Github':
-              (existingItem.content as GithubWidgetContentType).image =
-                returnedImage;
-              break;
-            case 'Behance':
-              (existingItem.content as BehanceWidgetContentType).image =
-                returnedImage;
-              break;
-            case 'Medium':
-              (existingItem.content as GithubWidgetContentType).image =
-                returnedImage;
-              break;
-            case 'TwitterProfile':
-              (existingItem.content as TwitterWidgetContentType).bannerImage =
-                returnedImage;
-              break;
-            case 'Youtube':
-              (existingItem.content as YoutubeWidgetContentType).thumbnail =
-                returnedImage;
-              break;
-            case 'Dribbble':
-              (existingItem.content as DribbbleWidgetContentType).image =
-                returnedImage;
-              break;
-            case 'LinkedInProfile':
-              (
-                existingItem.content as LinkedInProfileWidgetContentType
-              ).bannerImage = returnedImage;
-              break;
-
-            default:
-              break;
+        if (type === 'InstagramProfile') {
+          const toastMessage = await restoreInstagramWidgetAsync({
+            key,
+            redirectUrl,
+          });
+          if (toastMessage) {
+            toast(toastMessage.message, {
+              description: toastMessage.description,
+            });
           }
-          await updateWidgetContentAsync({
-            key: existingItem.i,
-            content: existingItem.content,
-          });
-
-          setLayout((prevLayout) => {
-            const newLayout = [...prevLayout, existingItem];
-            persistWidgetsLayoutOnChange(newLayout);
-            return newLayout;
-          });
-
-          // and if that site doesn't have an image, hold off on doing anything and inform the user.
         } else {
-          toast(`It looks like this site has no image for this URL`, {
-            description: `We won't update or delete the current image.`,
+          const returnedImage = await restoreWidgetImageAsync({
+            key,
+            type,
+            redirectUrl,
           });
+          // if image does exist, now you can update it
+          if (
+            returnedImage !== undefined &&
+            typeof returnedImage === 'string'
+          ) {
+            switch (existingItem.type) {
+              case 'Link':
+                (existingItem.content as LinkWidgetContentType).heroImageUrl =
+                  String(returnedImage);
+                break;
+              case 'SoundcloudSong':
+                (existingItem.content as SoundcloudTrackContentType).artwork =
+                  String(returnedImage);
+                break;
+              case 'Substack':
+                (existingItem.content as SubstackWidgetContentType).image =
+                  String(returnedImage);
+                break;
+              case 'Github':
+                (existingItem.content as GithubWidgetContentType).image =
+                  String(returnedImage);
+                break;
+              case 'Behance':
+                (existingItem.content as BehanceWidgetContentType).image =
+                  String(returnedImage);
+                break;
+              case 'Medium':
+                (existingItem.content as GithubWidgetContentType).image =
+                  String(returnedImage);
+                break;
+              case 'TwitterProfile':
+                (existingItem.content as TwitterWidgetContentType).bannerImage =
+                  String(returnedImage);
+                break;
+              case 'Youtube':
+                (existingItem.content as YoutubeWidgetContentType).thumbnail =
+                  String(returnedImage);
+                break;
+              case 'Dribbble':
+                (existingItem.content as DribbbleWidgetContentType).image =
+                  String(returnedImage);
+                break;
+              case 'LinkedInProfile':
+                (
+                  existingItem.content as LinkedInProfileWidgetContentType
+                ).bannerImage = String(returnedImage);
+                break;
+
+              default:
+                break;
+            }
+            await updateWidgetContentAsync({
+              key: existingItem.i,
+              content: existingItem.content,
+            });
+
+            setLayout((prevLayout) => {
+              const newLayout = [...prevLayout, existingItem];
+              persistWidgetsLayoutOnChange(newLayout);
+              return newLayout;
+            });
+          } else {
+            // and if that site doesn't have an image, hold off on doing anything and inform the user.
+            toast(`It looks like this site has no image for this URL`, {
+              description: `We won't update or delete the current image.`,
+            });
+          }
         }
-        setModifyingWidget(null);
       } catch (error) {
         const message =
           error instanceof Error ? error.message : 'Something went wrong';
         toast(`We couldn't update the picture`, {
           description: message,
         });
+      } finally {
+        setModifyingWidget(null);
       }
     },
     [
@@ -360,6 +378,45 @@ export const useWidgetManagement = ({
       updateWidgetContentAsync,
     ]
   );
+
+  /**
+   * else if (
+          returnedImage !== undefined &&
+          typeof returnedImage !== 'string'
+        ) {
+
+        const { handle, images, isPrivate } = returnedImage;
+          if (
+            (existingItem.content as InstagramWidgetContentType).images ===
+              images &&
+            !isPrivate
+          ) {
+            toast(`Looks like there's no new posts for this profile`, {
+              description: `We won't change the pictures for now, but you can manually upload your own photos if you want.`,
+            });
+          } else if (isPrivate) {
+            toast(`This account is private`, {
+              description: `We can't fetch any photos from this account, but you can manually upload your own photos if you want.`,
+            });
+          } else {
+            (existingItem.content as InstagramWidgetContentType).handle =
+              handle;
+            (existingItem.content as InstagramWidgetContentType).images =
+              images;
+            (existingItem.content as InstagramWidgetContentType).isPrivate =
+              isPrivate;
+
+            await updateWidgetContentAsync({
+              key: existingItem.i,
+              content: existingItem.content,
+            });
+
+            setLayout((prevLayout) => {
+              const newLayout = [...prevLayout, existingItem];
+              persistWidgetsLayoutOnChange(newLayout);
+              return newLayout;
+            });
+   */
 
   /** Handles the replacement of display images for Link and Photo Widgets */
   const handleImageRemoval = useCallback(
@@ -412,15 +469,24 @@ export const useWidgetManagement = ({
                 existingItem.content as LinkedInProfileWidgetContentType
               ).bannerImage = undefined;
               break;
+            case 'InstagramProfile':
+              (existingItem.content as InstagramWidgetContentType).images = [];
+              (
+                existingItem.content as InstagramWidgetContentType
+              ).replacementPicture = undefined;
+              break;
 
             default:
               break;
           }
+          console.log({
+            key: existingItem.i,
+            content: existingItem.content,
+          });
           await updateWidgetContentAsync({
             key: existingItem.i,
             content: existingItem.content,
           });
-          setModifyingWidget(null);
         }
       } catch (error) {
         const message =
@@ -428,9 +494,11 @@ export const useWidgetManagement = ({
         toast(`We couldn't remove the picture`, {
           description: message,
         });
+      } finally {
+        setModifyingWidget(null);
       }
     },
-    [layout, updateWidgetContentAsync]
+    [layout, modifyingWidget, updateWidgetContentAsync]
   );
 
   /** Handles the cropping of images, the id of the image being cropped should be passed */

--- a/src/hooks/widgets/useRestoreInstagramWidget.ts
+++ b/src/hooks/widgets/useRestoreInstagramWidget.ts
@@ -1,22 +1,18 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 
-import { restoreWidgetImage } from '@/api/widgets';
-import { WidgetType } from '@/types';
-
-export const useRestoreWidgetImage = () => {
+import { restoreInstagramWidget } from '@/api/widgets';
+export const useRestoreInstagramWidget = () => {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async ({
       key,
-      type,
       redirectUrl,
     }: {
       key: string;
-      type: WidgetType;
       redirectUrl: string;
-    }) => await restoreWidgetImage(key, type, redirectUrl),
+    }) => await restoreInstagramWidget(key, redirectUrl),
     onError: () =>
       toast('Failed to update widget', {
         description: 'If the issue persists, contact support',

--- a/src/types/widgets.ts
+++ b/src/types/widgets.ts
@@ -27,8 +27,7 @@ export interface BaseWidgetProps {
   handleRestoreImage: (
     key: string,
     type: WidgetType,
-    redirectUrl: string,
-    content: WidgetContentType
+    redirectUrl: string
   ) => Promise<void>;
 }
 
@@ -99,6 +98,7 @@ export interface InstagramWidgetContentType {
   handle: string;
   images: string[];
   isPrivate: boolean;
+  replacementPicture?: string; // for private or instagrams with no posts
 }
 
 export interface SoundcloudTrackContentType {


### PR DESCRIPTION
# [SRBT-355] Instagram widget image replacement and restoring

**Changes**

- Users can use the instagram profile's most recent posts, or they have the option of using a cover image. The precedent of which gets displaying is instagram posts (if they exist) -> cover image -> whatever appropriate placeholder text for when there's neither.
- Simplified `restoreWidgetImageAsync` to not need a content parameter to reduce payload size. Wasn't even needed for the corresponding backend function to work anyways.
- For handling image restorations for instagram widgets, a new endpoint was made and that gets called by `restoreInstagramWidgetAsync` instead of `restoreWidgetImageAsync`. For context, each individual instagram image is ~500 kb, which means the flow of fetching an image and then updating the widget with said image doesn't work because because that would make the payload of that second request too big.
- Change `onClick` to `onMouseDown` in `modify-image-controls.tsx` for reasons described in this previous [PR](https://github.com/MySorbet/sorbet-app/pull/152)

# Screenshots

https://github.com/user-attachments/assets/da177173-b25a-47c1-bf80-f018491c78f9

Ignore the flicker when I replace the image around ~0:30. That's due to me forgetting to refactor the `onClick` to `onMouseDown` (it's the widget moving positions because persistLayout got called twice). That's fixed now.
