### PR TITLE
Connect widget grid to network

### DIFF
--- a/.storybook/preview.ts
+++ b/.storybook/preview.ts
@@ -8,7 +8,10 @@ import { initialize, mswLoader } from 'msw-storybook-addon';
  * See https://github.com/mswjs/msw-storybook-addon#configuring-msw
  * to learn how to customize it
  */
-initialize();
+initialize({
+  // Stop MSW from logging a bunch of warnings in the console
+  onUnhandledRequest: 'bypass',
+});
 
 const preview: Preview = {
   parameters: {

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "docker:stop:dev": "docker compose -f docker/development/compose.yml down",
     "env": "gcloud secrets versions access latest --secret=sorbet-app-env-local --out-file=./.env && echo 'Local .env file updated successfully'",
     "env:push": "gcloud secrets versions add sorbet-app-env-local --data-file=./.env && gcloud secrets versions list sorbet-app-env-local --format='value(name)' | tail -n +2 | xargs -I {} gcloud secrets versions disable {} --secret=sorbet-app-env-local",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6300 --no-open",
     "sb": "yarn storybook",
     "build-storybook": "storybook build -o ./.storybook/storybook-static"
   },

--- a/src/api/images.ts
+++ b/src/api/images.ts
@@ -26,15 +26,25 @@ export const uploadProfileImageAsync = async (data: FormData) => {
   }
 };
 
-export const uploadWidgetsImageAsync = async (data: FormData) => {
+export const uploadWidgetsImageAsync = async (
+  data: FormData,
+  options?: {
+    signal?: AbortSignal;
+  }
+) => {
   try {
     const response = await axios.post(
       `${API_URL}/images/widgets`,
       data,
-      await withAuthHeader()
+      await withAuthHeader({
+        signal: options?.signal,
+      })
     );
     return response;
   } catch (error) {
+    if (axios.isCancel(error)) {
+      throw error;
+    }
     if (error instanceof AxiosError) {
       throw new Error(
         `Failed to upload widget image: ${error.response?.data.message}`

--- a/src/api/transactions/msw-handlers.ts
+++ b/src/api/transactions/msw-handlers.ts
@@ -20,8 +20,11 @@ export const mockTransactionsHandler = http.get(
 );
 
 export const mockOverviewHandler = http.get(
-  `${env.NEXT_PUBLIC_SORBET_API_URL}/transactions/overview?account=0x0000000000000000000000000000000000000000&last_days=30`,
-  async () => {
+  `${env.NEXT_PUBLIC_SORBET_API_URL}/transactions/overview`,
+  async ({ request }) => {
+    const params = new URL(request.url).searchParams;
+    const _account = params.get('account');
+    const _lastDays = params.get('last_days');
     await delay();
     return HttpResponse.json<TransactionOverview>({
       money_in: sampleTransactions,
@@ -34,8 +37,11 @@ export const mockOverviewHandler = http.get(
 );
 
 export const mockOverviewHandlerNoTransactions = http.get(
-  `${env.NEXT_PUBLIC_SORBET_API_URL}/transactions/overview?account=0x0000000000000000000000000000000000000000&last_days=30`,
-  async () => {
+  `${env.NEXT_PUBLIC_SORBET_API_URL}/transactions/overview`,
+  async ({ request }) => {
+    const params = new URL(request.url).searchParams;
+    const _account = params.get('account');
+    const _lastDays = params.get('last_days');
     await delay();
     return HttpResponse.json<TransactionOverview>({
       money_in: [],

--- a/src/api/widgets-v2.ts
+++ b/src/api/widgets-v2.ts
@@ -1,0 +1,91 @@
+import axios from 'axios';
+
+import { env } from '@/lib/env';
+
+import { withAuthHeader } from './withAuthHeader';
+
+const API_URL = env.NEXT_PUBLIC_SORBET_API_URL;
+
+type XYWH = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+export type LayoutDto = XYWH & {
+  id: string;
+  breakpoint: 'sm' | 'lg';
+};
+
+type CreateWidgetDto = {
+  id: string;
+  url: string;
+  layouts: {
+    sm: XYWH;
+    lg: XYWH;
+  };
+};
+
+export type UpdateLayoutsDto = {
+  layouts: LayoutDto[];
+};
+
+export type ApiWidget = {
+  id: string;
+  href?: string;
+  title?: string;
+  iconUrl?: string;
+  contentUrl?: string;
+  custom?: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+  userId: string;
+  layouts: LayoutDto[];
+};
+
+export const widgetsV2Api = {
+  /** Create a new widget */
+  create: async (data: CreateWidgetDto) => {
+    const response = await axios.post(
+      `${API_URL}/v2/widgets`,
+      data,
+      await withAuthHeader()
+    );
+    return response.data;
+  },
+
+  /** Update widget layouts */
+  updateLayouts: async (data: UpdateLayoutsDto) => {
+    await axios.put(
+      `${API_URL}/v2/widgets/layouts`,
+      data,
+      await withAuthHeader()
+    );
+  },
+
+  /** Delete a widget */
+  delete: async (id: string) => {
+    await axios.delete(`${API_URL}/v2/widgets/${id}`, await withAuthHeader());
+  },
+
+  /** Get widgets by handle */
+  getByHandle: async (handle: string) => {
+    const response = await axios.get(`${API_URL}/v2/widgets?handle=${handle}`);
+    return response.data;
+  },
+
+  /** Get widgets by userId */
+  getByUserId: async (userId: string) => {
+    const response = await axios.get(`${API_URL}/v2/widgets?userId=${userId}`);
+    return response.data;
+  },
+
+  /** Get widgets by privyId */
+  getByPrivyId: async (privyId: string) => {
+    const response = await axios.get(
+      `${API_URL}/v2/widgets?privyId=${privyId}`
+    );
+    return response.data;
+  },
+};

--- a/src/api/widgets-v2/images.ts
+++ b/src/api/widgets-v2/images.ts
@@ -1,0 +1,55 @@
+import { useMutation } from '@tanstack/react-query';
+import axios from 'axios';
+import { toast } from 'sonner';
+
+import { uploadWidgetsImageAsync } from '@/api/images';
+
+/**
+ * Capture the legacy form data for uploading widget images
+ */
+export const buildLegacyFormData = (image: File) => {
+  const fileExtension = image.name.split('.').pop()?.toLowerCase();
+  const formData = new FormData();
+  formData.append('file', image);
+
+  // fileType must be different for svgs to render correctly
+  if (fileExtension === 'svg') {
+    formData.append('fileType', 'image/svg+xml');
+  } else {
+    formData.append('fileType', 'image');
+  }
+  formData.append('destination', 'widgets');
+  formData.append('userId', '');
+
+  return formData;
+};
+
+/**
+ * Upload an `image` using the legacy API
+ */
+export const uploadWidgetImage = async (
+  image: File,
+  options?: {
+    signal?: AbortSignal;
+  }
+): Promise<string | undefined> => {
+  const formData = buildLegacyFormData(image);
+  const response = await uploadWidgetsImageAsync(formData, options);
+  if (response.data && response.data.fileUrl) {
+    return response.data.fileUrl;
+  } else {
+    throw new Error('Widget image not uploaded');
+  }
+};
+
+export const useUploadWidgetImage = () =>
+  useMutation({
+    mutationFn: uploadWidgetImage,
+    onError: (error) => {
+      if (!axios.isCancel(error)) {
+        toast('Failed to upload widget image', {
+          description: String(error),
+        });
+      }
+    },
+  });

--- a/src/api/widgets-v2/index.ts
+++ b/src/api/widgets-v2/index.ts
@@ -1,0 +1,3 @@
+export * from './msw-handlers';
+export * from './types';
+export * from './widgets-v2';

--- a/src/api/widgets-v2/msw-handlers.ts
+++ b/src/api/widgets-v2/msw-handlers.ts
@@ -1,0 +1,120 @@
+import { delay, http, HttpResponse } from 'msw';
+
+import { env } from '@/lib/env';
+
+import {
+  type ApiWidget,
+  type CreateWidgetDto,
+  type UpdateWidgetV2Dto,
+} from './types';
+
+// 👇 These handlers were AI generated and have not been tested or used yet
+
+const sampleWidget: ApiWidget = {
+  id: '123',
+  title: 'Sample Widget',
+  iconUrl: 'https://placehold.co/32/orange/white',
+  contentUrl: 'https://placehold.co/400/orange/white',
+  href: 'https://example.com',
+  createdAt: new Date(),
+  updatedAt: new Date(),
+  userId: '1',
+  layouts: [
+    { id: '123', x: 0, y: 0, w: 2, h: 2, breakpoint: 'sm' },
+    { id: '123', x: 0, y: 0, w: 4, h: 4, breakpoint: 'lg' },
+  ],
+};
+
+/**
+ * Mock the data from the `/v2/widgets` POST endpoint for creating widgets
+ */
+export const mockCreateWidgetHandler = http.post(
+  `${env.NEXT_PUBLIC_SORBET_API_URL}/v2/widgets`,
+  async ({ request }) => {
+    const data = (await request.json()) as CreateWidgetDto;
+    await delay();
+    return HttpResponse.json({
+      ...sampleWidget,
+      id: data.id,
+      layouts: [
+        { id: data.id, ...data.layouts.sm, breakpoint: 'sm' },
+        { id: data.id, ...data.layouts.lg, breakpoint: 'lg' },
+      ],
+    });
+  }
+);
+
+/**
+ * Mock the data from the `/v2/widgets/layouts` PUT endpoint for updating layouts
+ */
+export const mockUpdateLayoutsHandler = http.put(
+  `${env.NEXT_PUBLIC_SORBET_API_URL}/v2/widgets/layouts`,
+  async () => {
+    await delay();
+    return new HttpResponse(null, { status: 200 });
+  }
+);
+
+/**
+ * Mock the data from the `/v2/widgets/:id` DELETE endpoint
+ */
+export const mockDeleteWidgetHandler = http.delete(
+  `${env.NEXT_PUBLIC_SORBET_API_URL}/v2/widgets/:id`,
+  async () => {
+    await delay();
+    return new HttpResponse(null, { status: 200 });
+  }
+);
+
+/**
+ * Mock the data from the `/v2/widgets` GET endpoint with query params
+ */
+export const mockGetWidgetsHandler = http.get(
+  `${env.NEXT_PUBLIC_SORBET_API_URL}/v2/widgets`,
+  async () => {
+    await delay();
+    return HttpResponse.json([sampleWidget]);
+  }
+);
+
+/**
+ * Mock the data from the `/v2/widgets/:id` PUT endpoint for updating widget properties
+ */
+export const mockUpdateWidgetHandler = http.put(
+  `${env.NEXT_PUBLIC_SORBET_API_URL}/v2/widgets/:id`,
+  async ({ params, request }) => {
+    const { id } = params;
+    const updateData = (await request.json()) as UpdateWidgetV2Dto;
+    await delay();
+
+    return HttpResponse.json({
+      ...sampleWidget,
+      id: id as string,
+      title: updateData.title,
+      contentUrl: updateData.contentUrl,
+      custom: updateData.custom,
+      updatedAt: new Date(),
+    });
+  }
+);
+
+/**
+ * Mock the data from the `/v2/widgets/:id/enrich` POST endpoint
+ */
+export const mockEnrichWidgetHandler = http.post(
+  `${env.NEXT_PUBLIC_SORBET_API_URL}/v2/widgets/:id/enrich`,
+  async ({ params }) => {
+    const { id } = params;
+    await delay();
+
+    return HttpResponse.json({
+      ...sampleWidget,
+      id: id as string,
+      title: 'Enriched Title',
+      iconUrl: 'https://placehold.co/32/orange/white',
+      contentUrl: 'https://placehold.co/400/orange/white',
+      href: 'https://example.com',
+      updatedAt: new Date(),
+    });
+  }
+);

--- a/src/api/widgets-v2/types.ts
+++ b/src/api/widgets-v2/types.ts
@@ -10,14 +10,29 @@ export type LayoutDto = XYWH & {
   breakpoint: 'sm' | 'lg';
 };
 
-export type CreateWidgetDto = {
+export type WidgetType = 'image';
+
+export type BaseCreateWidgetDto = {
   id: string;
-  url: string;
+  url?: string;
+  type?: WidgetType;
   layouts: {
     sm: XYWH;
     lg: XYWH;
   };
 };
+
+export type CreateWidgetUrlDto = BaseCreateWidgetDto & {
+  url: string;
+  // regular url creation must have a url
+};
+
+export type CreateWidgetImageDto = BaseCreateWidgetDto & {
+  type: 'image';
+  // image creation will not have a url
+};
+
+export type CreateWidgetDto = CreateWidgetUrlDto | CreateWidgetImageDto;
 
 export type UpdateLayoutsDto = {
   layouts: LayoutDto[];
@@ -40,6 +55,7 @@ export type ApiWidget = {
   title?: string;
   iconUrl?: string;
   contentUrl?: string;
+  type?: WidgetType;
   custom?: Record<string, unknown>;
   createdAt: Date;
   updatedAt: Date;

--- a/src/api/widgets-v2/types.ts
+++ b/src/api/widgets-v2/types.ts
@@ -1,0 +1,48 @@
+type XYWH = {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+};
+
+export type LayoutDto = XYWH & {
+  id: string;
+  breakpoint: 'sm' | 'lg';
+};
+
+export type CreateWidgetDto = {
+  id: string;
+  url: string;
+  layouts: {
+    sm: XYWH;
+    lg: XYWH;
+  };
+};
+
+export type UpdateLayoutsDto = {
+  layouts: LayoutDto[];
+};
+
+export type UpdateWidgetV2Dto = {
+  /** The title of the widget */
+  title?: string;
+
+  /** The content URL of the widget */
+  contentUrl?: string;
+
+  /** Any custom data for the widget */
+  custom?: Record<string, unknown>;
+};
+
+export type ApiWidget = {
+  id: string;
+  href?: string;
+  title?: string;
+  iconUrl?: string;
+  contentUrl?: string;
+  custom?: Record<string, unknown>;
+  createdAt: Date;
+  updatedAt: Date;
+  userId: string;
+  layouts: LayoutDto[];
+};

--- a/src/api/widgets-v2/widgets-v2.ts
+++ b/src/api/widgets-v2/widgets-v2.ts
@@ -3,7 +3,12 @@ import axios from 'axios';
 import { env } from '@/lib/env';
 
 import { withAuthHeader } from '../withAuthHeader';
-import { ApiWidget, CreateWidgetDto, UpdateLayoutsDto } from './types';
+import {
+  ApiWidget,
+  CreateWidgetDto,
+  UpdateLayoutsDto,
+  UpdateWidgetV2Dto,
+} from './types';
 
 const API_URL = env.NEXT_PUBLIC_SORBET_API_URL;
 
@@ -60,6 +65,16 @@ export const widgetsV2Api = {
   enrich: async (id: string) => {
     const response = await axios.post<ApiWidget>(
       `${API_URL}/v2/widgets/${id}/enrich`,
+      await withAuthHeader()
+    );
+    return response.data;
+  },
+
+  /** Update a widget */
+  update: async (id: string, data: UpdateWidgetV2Dto) => {
+    const response = await axios.put<ApiWidget>(
+      `${API_URL}/v2/widgets/${id}`,
+      data,
       await withAuthHeader()
     );
     return response.data;

--- a/src/api/widgets-v2/widgets-v2.ts
+++ b/src/api/widgets-v2/widgets-v2.ts
@@ -2,52 +2,15 @@ import axios from 'axios';
 
 import { env } from '@/lib/env';
 
-import { withAuthHeader } from './withAuthHeader';
+import { withAuthHeader } from '../withAuthHeader';
+import { ApiWidget, CreateWidgetDto, UpdateLayoutsDto } from './types';
 
 const API_URL = env.NEXT_PUBLIC_SORBET_API_URL;
-
-type XYWH = {
-  x: number;
-  y: number;
-  w: number;
-  h: number;
-};
-
-export type LayoutDto = XYWH & {
-  id: string;
-  breakpoint: 'sm' | 'lg';
-};
-
-type CreateWidgetDto = {
-  id: string;
-  url: string;
-  layouts: {
-    sm: XYWH;
-    lg: XYWH;
-  };
-};
-
-export type UpdateLayoutsDto = {
-  layouts: LayoutDto[];
-};
-
-export type ApiWidget = {
-  id: string;
-  href?: string;
-  title?: string;
-  iconUrl?: string;
-  contentUrl?: string;
-  custom?: Record<string, unknown>;
-  createdAt: Date;
-  updatedAt: Date;
-  userId: string;
-  layouts: LayoutDto[];
-};
 
 export const widgetsV2Api = {
   /** Create a new widget */
   create: async (data: CreateWidgetDto) => {
-    const response = await axios.post(
+    const response = await axios.post<ApiWidget>(
       `${API_URL}/v2/widgets`,
       data,
       await withAuthHeader()
@@ -71,20 +34,33 @@ export const widgetsV2Api = {
 
   /** Get widgets by handle */
   getByHandle: async (handle: string) => {
-    const response = await axios.get(`${API_URL}/v2/widgets?handle=${handle}`);
+    const response = await axios.get<ApiWidget[]>(
+      `${API_URL}/v2/widgets?handle=${handle}`
+    );
     return response.data;
   },
 
   /** Get widgets by userId */
   getByUserId: async (userId: string) => {
-    const response = await axios.get(`${API_URL}/v2/widgets?userId=${userId}`);
+    const response = await axios.get<ApiWidget[]>(
+      `${API_URL}/v2/widgets?userId=${userId}`
+    );
     return response.data;
   },
 
   /** Get widgets by privyId */
   getByPrivyId: async (privyId: string) => {
-    const response = await axios.get(
+    const response = await axios.get<ApiWidget[]>(
       `${API_URL}/v2/widgets?privyId=${privyId}`
+    );
+    return response.data;
+  },
+
+  /** Enrich a widget */
+  enrich: async (id: string) => {
+    const response = await axios.post<ApiWidget>(
+      `${API_URL}/v2/widgets/${id}/enrich`,
+      await withAuthHeader()
     );
     return response.data;
   },

--- a/src/app/v2/[handle]/components/profile.stories.tsx
+++ b/src/app/v2/[handle]/components/profile.stories.tsx
@@ -16,7 +16,7 @@ const meta = {
   decorators: [
     (Story) => (
       <div className='h-screen w-full'>
-        <WidgetProvider>
+        <WidgetProvider userId={mockUser.id}>
           <Story />
         </WidgetProvider>
       </div>

--- a/src/app/v2/[handle]/components/profile.tsx
+++ b/src/app/v2/[handle]/components/profile.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { useState } from 'react';
+import { ErrorBoundary } from 'react-error-boundary';
 import { toast } from 'sonner';
 
 // TODO: Move to ./components
@@ -13,6 +14,7 @@ import { ControlBar } from './control-bar/control-bar';
 import { ProfileDetails } from './profile-details';
 import { ShareDialog } from './share-dialog/share-dialog';
 import { WidgetGrid } from './widget/grid';
+import { GridErrorFallback } from './widget/grid-error-fallback';
 import { useWidgets } from './widget/use-widget-context';
 
 /** Profile 2.0 */
@@ -72,7 +74,9 @@ export const Profile = ({
         {/* The right side of the profile. Should handle scroll itself */}
         {/* Container queries set this up to be responsive to the flex change on at 3xl. TODO: Still something isn't quite right */}
         <div className='@3xl:w-auto @3xl:h-full w-full flex-1'>
-          <WidgetGrid immutable={!isMine} />
+          <ErrorBoundary FallbackComponent={GridErrorFallback}>
+            <WidgetGrid immutable={!isMine} />
+          </ErrorBoundary>
         </div>
 
         {/* Elements which ignore the layout of this container */}

--- a/src/app/v2/[handle]/components/profile.tsx
+++ b/src/app/v2/[handle]/components/profile.tsx
@@ -3,7 +3,6 @@
 import Link from 'next/link';
 import { useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { toast } from 'sonner';
 
 // TODO: Move to ./components
 import { EditProfileSheet } from '@/components/profile/edit-profile-sheet';
@@ -30,12 +29,10 @@ export const Profile = ({
   const [isEditing, setIsEditing] = useState(false);
   const [isShareDialogOpen, setIsShareDialogOpen] = useState(false);
 
-  const { addWidget } = useWidgets();
+  const { addWidget, addImage } = useWidgets();
 
-  const handleAddImage = (image: File) => {
-    toast.success('Would add image', {
-      description: image.name,
-    });
+  const handleAddImage = async (image: File) => {
+    addImage(image);
   };
 
   const handleAddLink = (link: string) => {

--- a/src/app/v2/[handle]/components/widget/grid-config.ts
+++ b/src/app/v2/[handle]/components/widget/grid-config.ts
@@ -53,6 +53,7 @@ export type WidgetData = {
   iconUrl?: string;
   id: string;
   title?: string;
+  type?: 'image';
 };
 
 // This is widget data augmented with display metadata.

--- a/src/app/v2/[handle]/components/widget/grid-config.ts
+++ b/src/app/v2/[handle]/components/widget/grid-config.ts
@@ -52,7 +52,7 @@ export type WidgetData = {
   href?: string;
   iconUrl?: string;
   id: string;
-  title: string;
+  title?: string;
 };
 
 // This is widget data augmented with display metadata.

--- a/src/app/v2/[handle]/components/widget/grid-error-fallback.tsx
+++ b/src/app/v2/[handle]/components/widget/grid-error-fallback.tsx
@@ -1,0 +1,39 @@
+import { AlertCircle } from 'lucide-react';
+import { FallbackProps } from 'react-error-boundary';
+
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+
+/**
+ * A fallback component to be passed to `<ErrorBoundary/>` that is displayed when an error occurs in the widget grid.
+ *
+ * It renders an alert with an error message and a button to reset the error boundary and rerender the UI inside of the `<ErrorBoundary/>`.
+ */
+export const GridErrorFallback: React.ComponentType<FallbackProps> = () => {
+  return (
+    <div className='flex size-full items-center justify-center'>
+      <Alert variant='destructive' className='w-fit'>
+        <AlertCircle className='size-4' />
+        <AlertTitle>Whoops</AlertTitle>
+        <AlertDescription>
+          Something broke. Let's try this again.
+        </AlertDescription>
+        <div className='flex`'>
+          <Button
+            variant='secondary'
+            onClick={() => {
+              // So far, the only known issue repo is
+              // add a widget, move another into its place while the api call to create it has not returned, then drop the widget you are holding
+              // in the rgl map, the widget cannot be found when the layout tries to update.
+              // We mitigated this by returning null for now. So there are no known cases when this renders
+              window.location.reload();
+            }}
+            className='mt-2'
+          >
+            Refresh
+          </Button>
+        </div>
+      </Alert>
+    </div>
+  );
+};

--- a/src/app/v2/[handle]/components/widget/grid.stories.tsx
+++ b/src/app/v2/[handle]/components/widget/grid.stories.tsx
@@ -1,5 +1,6 @@
 import { Meta, StoryObj } from '@storybook/react';
 
+import { mockUserMinimal } from '@/api/user/mock-user';
 import { Button } from '@/components/ui/button';
 import { sleep } from '@/lib/utils';
 
@@ -14,7 +15,7 @@ const meta = {
   },
   decorators: [
     (Story) => (
-      <WidgetProvider>
+      <WidgetProvider userId={mockUserMinimal.id}>
         <Story />
       </WidgetProvider>
     ),

--- a/src/app/v2/[handle]/components/widget/grid.tsx
+++ b/src/app/v2/[handle]/components/widget/grid.tsx
@@ -73,12 +73,18 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
         >
           {layouts[breakpoint].map((layout) => {
             const widget = widgets[layout.i];
+
+            // It's possible for a bag to happen where the layout has an id that is not in the widgets map
+            // It would be better to be more explicit here and throw, but this provides a nicer experience and seems to cause no issues.
+            if (!widget) {
+              // throw new Error(`Widget with id ${layout.i} not found`);
+              console.error(`Widget with id ${layout.i} not found`);
+              return null;
+            }
             const s = size(layout.w, layout.h);
-            // TODO: Is it possible that you don't find a widget? and if so maybe throw and wrap with error boundary?
             return (
               <RGLHandle
                 key={widget.id}
-                className='group'
                 size={s}
                 id={widget.id}
                 draggedRef={draggedRef}
@@ -141,7 +147,7 @@ const RGLHandle = React.forwardRef<HTMLDivElement, RGLHandleProps>(
       <div
         style={style}
         className={cn(
-          'relative isolate',
+          'group relative isolate',
           debug && 'border-divider rounded-2xl border-2 border-dashed',
           className
         )}
@@ -151,7 +157,6 @@ const RGLHandle = React.forwardRef<HTMLDivElement, RGLHandleProps>(
         onTouchEnd={onTouchEnd}
         // TODO: This just prevents a widget from being clicked when dropping. Fix this an make them clickable
         onClick={(e) => {
-          console.log('clicked');
           e.preventDefault();
         }}
         {...props}

--- a/src/app/v2/[handle]/components/widget/grid.tsx
+++ b/src/app/v2/[handle]/components/widget/grid.tsx
@@ -20,6 +20,7 @@ import {
   wSm,
 } from './grid-config';
 import styles from './rgl-custom.module.css';
+import { useHandlePaste } from './use-handle-paste';
 import { useWidgets } from './use-widget-context';
 import { Widget } from './widget';
 import { WidgetControls } from './widget-controls';
@@ -37,11 +38,19 @@ const ResponsiveGridLayout = WidthProvider(Responsive);
  * It will also break between a sm and lg size, based on it's own width using a container query.
  */
 export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
-  const { widgets, layouts, breakpoint, setBreakpoint, onLayoutChange } =
-    useWidgets();
+  const {
+    widgets,
+    layouts,
+    breakpoint,
+    setBreakpoint,
+    onLayoutChange,
+    addWidget,
+  } = useWidgets();
   const width = gw(breakpoint);
 
   const draggedRef = useRef<boolean>(false);
+
+  useHandlePaste(addWidget);
 
   return (
     <ScrollArea className='@container size-full'>

--- a/src/app/v2/[handle]/components/widget/grid.tsx
+++ b/src/app/v2/[handle]/components/widget/grid.tsx
@@ -99,14 +99,7 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
                 draggedRef={draggedRef}
                 hideControls={immutable}
               >
-                <Widget
-                  title={widget.title}
-                  iconUrl={widget.iconUrl}
-                  contentUrl={widget.contentUrl}
-                  href={widget.href}
-                  size={s}
-                  loading={widget.loading}
-                />
+                <Widget {...widget} size={s} />
               </RGLHandle>
             );
           })}

--- a/src/app/v2/[handle]/components/widget/grid.tsx
+++ b/src/app/v2/[handle]/components/widget/grid.tsx
@@ -86,9 +86,11 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
               >
                 <Widget
                   title={widget.title}
-                  size={s}
+                  iconUrl={widget.iconUrl}
                   contentUrl={widget.contentUrl}
                   href={widget.href}
+                  size={s}
+                  loading={widget.loading}
                 />
               </RGLHandle>
             );

--- a/src/app/v2/[handle]/components/widget/image-widget.tsx
+++ b/src/app/v2/[handle]/components/widget/image-widget.tsx
@@ -1,0 +1,57 @@
+import { ImageOff } from 'lucide-react';
+
+import { Spinner } from '@/components/common/spinner';
+import { TooltipContent, TooltipProvider } from '@/components/ui/tooltip';
+import { Tooltip, TooltipTrigger } from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+interface ImageWidgetProps {
+  /** The url of the image to display. If not provided, the widget will display an error state. */
+  contentUrl?: string;
+  /** Additional classes to apply to the widget. */
+  className?: string;
+  /** Whether the widget is loading (image upload in progress). If true, the widget will display a spinner. */
+  loading?: boolean;
+}
+
+/**
+ * Full bleed image widget. To be rendered by a higher up widget component.
+ */
+export const ImageWidget: React.FC<ImageWidgetProps> = ({
+  contentUrl,
+  className,
+  loading,
+}) => {
+  return (
+    <div
+      className={cn(
+        'relative size-full overflow-hidden rounded-2xl',
+        className
+      )}
+    >
+      {contentUrl ? (
+        <>
+          <img
+            src={contentUrl}
+            alt='Photo content'
+            className='size-full object-cover'
+          />
+          {loading && <Spinner className='absolute left-4 top-4' />}
+        </>
+      ) : (
+        <div className='bg-muted flex size-full items-center justify-center'>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger>
+                <ImageOff className='text-muted-foreground size-8' />
+              </TooltipTrigger>
+              <TooltipContent className='max-w-56'>
+                Something isn't right with this image. Delete it and try again.
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        </div>
+      )}
+    </div>
+  );
+};

--- a/src/app/v2/[handle]/components/widget/use-abort-map.ts
+++ b/src/app/v2/[handle]/components/widget/use-abort-map.ts
@@ -1,0 +1,67 @@
+import { useEffect, useRef } from 'react';
+
+/**
+ * Hook to manage a map of abort controllers to the ids of the operations that they are associated with.
+ * This is useful for cancelling ongoing operations when a new operation is started.
+ *
+ * All operations will be aborted when the component using this hook unmounts.
+ * All operations will be aborted when the page is refreshed. (this is probably redundant, but it's a good precaution)
+ */
+export function useAbortMap() {
+  const abortControllersRef = useRef<Record<string, AbortController>>({});
+
+  /** Add a new abort controller for an operation */
+  const addController = (id: string) => {
+    const controller = new AbortController();
+    abortControllersRef.current[id] = controller;
+    return controller;
+  };
+
+  /** Get the abort controller for an operation if it exists */
+  const getController = (id: string) => {
+    return abortControllersRef.current[id];
+  };
+
+  /** Abort an operation if it exists. Remove the controller from the map. */
+  const abortAndRemove = (id: string) => {
+    const controller = abortControllersRef.current[id];
+    if (controller) {
+      controller.abort();
+      delete abortControllersRef.current[id];
+    }
+  };
+
+  /** Remove an operation's controller without aborting */
+  const removeController = (id: string) => {
+    delete abortControllersRef.current[id];
+  };
+
+  /** Abort all pending operations */
+  const abortAll = () => {
+    Object.values(abortControllersRef.current).forEach((controller) => {
+      controller.abort();
+    });
+    abortControllersRef.current = {};
+  };
+
+  // Set up page unload handler
+  useEffect(() => {
+    const handleUnload = () => {
+      abortAll();
+    };
+
+    window.addEventListener('beforeunload', handleUnload);
+    return () => {
+      window.removeEventListener('beforeunload', handleUnload);
+      // Also abort everything when the component using this hook unmounts
+      abortAll();
+    };
+  }, []);
+
+  return {
+    addController,
+    getController,
+    abortAndRemove,
+    removeController,
+  };
+}

--- a/src/app/v2/[handle]/components/widget/use-handle-paste.ts
+++ b/src/app/v2/[handle]/components/widget/use-handle-paste.ts
@@ -1,0 +1,44 @@
+import { useEffect } from 'react';
+
+import { normalizeUrl } from '@/components/profile/widgets/util';
+
+/** Hook that handles pasting URLs globally, ignoring paste events in input elements */
+export const useHandlePaste = (onPasteUrl: (url: string) => void) =>
+  useEffect(() => {
+    const handlePaste = (event: ClipboardEvent) => {
+      // Don't handle if another component has already handled this paste
+      if (event.defaultPrevented) {
+        return;
+      }
+
+      // Don't handle paste events in input-like elements
+      const target = event.target as HTMLElement;
+      if (
+        target instanceof HTMLInputElement ||
+        target instanceof HTMLTextAreaElement ||
+        target.isContentEditable
+      ) {
+        return;
+      }
+
+      try {
+        const text = event.clipboardData?.getData('text/plain');
+        if (!text) return;
+
+        const normalizedUrl = normalizeUrl(text);
+        if (normalizedUrl) {
+          // Prevent other paste handlers since we're handling this URL
+          event.preventDefault();
+          onPasteUrl(normalizedUrl);
+        }
+      } catch (error) {
+        // Silent fail - if we can't handle the paste, let other handlers try
+        console.error('Failed to handle paste event:', error);
+      }
+    };
+
+    window.addEventListener('paste', handlePaste);
+    return () => {
+      window.removeEventListener('paste', handlePaste);
+    };
+  }, [onPasteUrl]);

--- a/src/app/v2/[handle]/components/widget/use-pending-widgets.ts
+++ b/src/app/v2/[handle]/components/widget/use-pending-widgets.ts
@@ -1,0 +1,26 @@
+import { useState } from 'react';
+
+/** Hook to track pending widget operations */
+export function usePendingWidgets() {
+  const [pendingWidgets, setPendingWidgets] = useState(new Set<string>());
+
+  const addPending = (id: string) => {
+    setPendingWidgets((prev) => new Set(prev).add(id));
+  };
+
+  const removePending = (id: string) => {
+    setPendingWidgets((prev) => {
+      const next = new Set(prev);
+      next.delete(id);
+      return next;
+    });
+  };
+
+  const isPending = (id: string) => pendingWidgets.has(id);
+
+  return {
+    addPending,
+    removePending,
+    isPending,
+  };
+}

--- a/src/app/v2/[handle]/components/widget/use-widget-context.tsx
+++ b/src/app/v2/[handle]/components/widget/use-widget-context.tsx
@@ -155,13 +155,16 @@ function widgetReducer(state: WidgetState, action: WidgetAction): WidgetState {
      */
     case 'UPDATE_WIDGET_SIZE': {
       const { id, size } = action.payload;
-      const newLayouts = {
-        sm: updateLayoutSize(state.layouts.sm, id, LayoutSizes[size]),
-        lg: updateLayoutSize(state.layouts.lg, id, LayoutSizes[size]),
-      };
       return {
         ...state,
-        layouts: newLayouts,
+        layouts: {
+          ...state.layouts,
+          [state.breakpoint]: updateLayoutSize(
+            state.layouts[state.breakpoint],
+            id,
+            LayoutSizes[size]
+          ),
+        },
       };
     }
 

--- a/src/app/v2/[handle]/components/widget/use-widget-context.tsx
+++ b/src/app/v2/[handle]/components/widget/use-widget-context.tsx
@@ -1,10 +1,17 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
+import axios from 'axios';
 import React, { createContext, useContext, useReducer } from 'react';
 import { type Layout } from 'react-grid-layout';
 import { toast } from 'sonner';
 import { v4 as uuidv4 } from 'uuid';
 
-import { type ApiWidget, LayoutDto, widgetsV2Api } from '@/api/widgets-v2';
+import {
+  type ApiWidget,
+  LayoutDto,
+  widgetsV2Api,
+  WidgetType,
+} from '@/api/widgets-v2';
+import { uploadWidgetImage } from '@/api/widgets-v2/images';
 
 import {
   type Breakpoint,
@@ -12,6 +19,7 @@ import {
   LayoutSizes,
   WidgetSize,
 } from './grid-config';
+import { useAbortMap } from './use-abort-map';
 import { usePendingWidgets } from './use-pending-widgets';
 
 // Types for widget data
@@ -20,7 +28,7 @@ type WidgetMap = Record<string, LoadableWidget>;
 type LayoutMap = Record<Breakpoint, Layout[]>;
 
 // Action payloads
-type AddWidgetStartPayload = { id: string; url: string };
+type AddWidgetStartPayload = { id: string; url: string; type?: WidgetType };
 type AddWidgetCompletePayload = { id: string; data: Omit<WidgetData, 'id'> };
 type RemoveWidgetPayload = { id: string };
 type UpdateLayoutsPayload = { layouts: LayoutMap };
@@ -63,9 +71,17 @@ interface WidgetContextType {
   updateSize: (id: string, size: WidgetSize) => void;
   /** Remove a widget */
   removeWidget: (id: string) => void;
+  /** Add an image widget */
+  addImage: (image: File) => void;
 }
 
 const WidgetContext = createContext<WidgetContextType | null>(null);
+
+const DEFAULT_WIDGET_LAYOUT = {
+  x: 0,
+  y: 0,
+  ...LayoutSizes['B'],
+};
 
 function widgetReducer(state: WidgetState, action: WidgetAction): WidgetState {
   switch (action.type) {
@@ -75,21 +91,23 @@ function widgetReducer(state: WidgetState, action: WidgetAction): WidgetState {
      * This will update both layout data and widget data
      */
     case 'ADD_WIDGET_START': {
-      const { id, url } = action.payload;
+      const { id, url, type } = action.payload;
       return {
         ...state,
         widgets: {
           ...state.widgets,
           [id]: {
             id,
-            href: url,
+            href: type === 'image' ? undefined : url,
+            contentUrl: type === 'image' ? url : undefined,
+            type,
             loading: true,
           },
         },
         // Add widget with default size to both breakpoints
         layouts: {
-          sm: [{ i: id, ...LayoutSizes['B'], x: 0, y: 0 }, ...state.layouts.sm],
-          lg: [{ i: id, ...LayoutSizes['B'], x: 0, y: 0 }, ...state.layouts.lg],
+          sm: [{ i: id, ...DEFAULT_WIDGET_LAYOUT }, ...state.layouts.sm],
+          lg: [{ i: id, ...DEFAULT_WIDGET_LAYOUT }, ...state.layouts.lg],
         },
       };
     }
@@ -205,11 +223,20 @@ export function WidgetProvider({
   children: React.ReactNode;
   userId: string;
 }) {
+  // The widget reducer manages grid state
   const [state, dispatch] = useReducer(widgetReducer, {
     widgets: {},
     layouts: { sm: [], lg: [] },
     breakpoint: 'lg',
   });
+
+  // This is a little hack to keep track of the ids of widgets that have been added to UI, but we don't know if the API
+  // has returned successfully. When layout changes happen, we choose not to update layouts for these widgets.
+  // I wonder if we should just make these static until the call has completed? It shouldn't be too long.
+  const { addPending, removePending, isPending } = usePendingWidgets();
+
+  // We use this to abort image uploads when an image widget is delete while an upload is in progress
+  const { addController, removeController, abortAndRemove } = useAbortMap();
 
   // Load initial widgets
   const { data: widgets } = useQuery<ApiWidget[], Error>({
@@ -218,11 +245,6 @@ export function WidgetProvider({
     staleTime: Infinity,
     refetchOnWindowFocus: false,
   });
-
-  // This is a little hack to keep track of the ids of widgets that have been added to UI, but we don't know if the API
-  // has returned successfully. When layout changes happen, we choose not to update layouts for these widgets.
-  // I wonder if we should just make these static until the call has completed? It shouldn't be too long.
-  const { addPending, removePending, isPending } = usePendingWidgets();
 
   // Transform and dispatch data when it arrives
   React.useEffect(() => {
@@ -241,8 +263,8 @@ export function WidgetProvider({
         id: params.id,
         url: params.url,
         layouts: {
-          sm: { ...LayoutSizes['B'], x: 0, y: 0 },
-          lg: { ...LayoutSizes['B'], x: 0, y: 0 },
+          sm: DEFAULT_WIDGET_LAYOUT,
+          lg: DEFAULT_WIDGET_LAYOUT,
         },
       }),
     onMutate: ({ id, url }) => {
@@ -285,6 +307,90 @@ export function WidgetProvider({
       });
       toast.error("We couldn't add that link", {
         description: error.message,
+      });
+    },
+  });
+
+  const createImageWidgetMutation = useMutation({
+    mutationFn: async (params: { id: string; image: File }) => {
+      try {
+        // First create the widget in the database (at this point, it is invalid since it has no contentUrl)
+        const widget = await widgetsV2Api.create({
+          id: params.id,
+          type: 'image',
+          layouts: {
+            sm: DEFAULT_WIDGET_LAYOUT,
+            lg: DEFAULT_WIDGET_LAYOUT,
+          },
+        });
+
+        // Then upload the image with abort signal
+        const abortController = addController(params.id);
+        const contentUrl = await uploadWidgetImage(params.image, {
+          signal: abortController.signal,
+        });
+
+        // Then update the widget with the image URL
+        await widgetsV2Api.update(widget.id, {
+          contentUrl,
+        });
+
+        return { ...widget, contentUrl };
+      } catch (error) {
+        // If the error is from an abort, we want to propagate it
+        if (axios.isCancel(error)) {
+          throw error;
+        }
+        throw error;
+      } finally {
+        removeController(params.id);
+      }
+    },
+
+    onMutate: ({ id, image }) => {
+      const tempUrl = URL.createObjectURL(image);
+      addPending(id);
+      dispatch({
+        type: 'ADD_WIDGET_START',
+        payload: { id, url: tempUrl, type: 'image' },
+      });
+      return { tempUrl };
+    },
+
+    onSuccess: async ({ id, contentUrl }, _, context) => {
+      removePending(id);
+      if (context?.tempUrl) {
+        URL.revokeObjectURL(context.tempUrl);
+      }
+      dispatch({
+        type: 'ADD_WIDGET_COMPLETE',
+        payload: {
+          id,
+          data: {
+            contentUrl,
+            type: 'image',
+          },
+        },
+      });
+    },
+
+    onError: (error, { id }, context) => {
+      // Don't show error toast if it was just aborted
+      if (!axios.isCancel(error)) {
+        console.error('Failed to create image widget:', error);
+        toast.error("We couldn't add that image", {
+          description: String(error),
+        });
+      }
+
+      if (context?.tempUrl) {
+        URL.revokeObjectURL(context.tempUrl);
+      }
+
+      removePending(id);
+      dispatch({
+        type: 'REMOVE_WIDGET',
+        payload: { id },
       });
     },
   });
@@ -335,7 +441,13 @@ export function WidgetProvider({
     // mutation handles complex dispatching logic
   };
 
+  const addImage = (image: File) => {
+    const id = uuidv4();
+    createImageWidgetMutation.mutate({ id, image });
+  };
+
   const removeWidget = (id: string) => {
+    abortAndRemove(id); // Abort any ongoing upload
     dispatch({ type: 'REMOVE_WIDGET', payload: { id } });
     deleteMutation.mutate(id);
   };
@@ -364,6 +476,7 @@ export function WidgetProvider({
         setBreakpoint,
         onLayoutChange,
         addWidget,
+        addImage,
         updateSize,
         removeWidget,
       }}

--- a/src/app/v2/[handle]/components/widget/widget.tsx
+++ b/src/app/v2/[handle]/components/widget/widget.tsx
@@ -7,6 +7,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 
 import { WidgetDataForDisplay } from './grid-config';
+import { ImageWidget } from './image-widget';
 
 /**
  * The most basic component to display a widget as an anchor tag styled as a card.
@@ -23,8 +24,19 @@ export const Widget = ({
   contentUrl,
   href,
   loading = false,
+  type,
   size = 'A',
 }: WidgetDataForDisplay) => {
+  if (type === 'image') {
+    return (
+      <ImageWidget
+        contentUrl={contentUrl}
+        className='animate-in fade-in-0 zoom-in-0 max-h-[390px] max-w-[390px] duration-300'
+        loading={loading}
+      />
+    );
+  }
+
   return (
     <a
       className={cn(

--- a/src/app/v2/[handle]/components/widget/widget.tsx
+++ b/src/app/v2/[handle]/components/widget/widget.tsx
@@ -37,6 +37,8 @@ export const Widget = ({
       href={href}
       target='_blank'
       rel='noopener noreferrer'
+      draggable={false} // disable HTML5 dnd
+      // TODO: Consider allowing dragging links to other programs with ondragstart="event.dataTransfer.setData('text/plain', href)">
     >
       <CardHeader className='pb-10'>
         {loading ? <Skeleton className='size-10' /> : <Icon src={iconUrl} />}

--- a/src/app/v2/[handle]/components/widget/widget.tsx
+++ b/src/app/v2/[handle]/components/widget/widget.tsx
@@ -1,5 +1,6 @@
 import { Link } from 'lucide-react';
 import React from 'react';
+import { parseURL } from 'ufo';
 
 import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -43,7 +44,7 @@ export const Widget = ({
       <CardHeader className='pb-10'>
         {loading ? <Skeleton className='size-10' /> : <Icon src={iconUrl} />}
         <CardTitle className='line-clamp-3 text-sm font-normal'>
-          {title}
+          {title || parseURL(href).host || href}
         </CardTitle>
       </CardHeader>
       {/* TODO: Perhaps you could extract all the size conditionals to this container? */}

--- a/src/app/v2/[handle]/page.tsx
+++ b/src/app/v2/[handle]/page.tsx
@@ -51,7 +51,7 @@ const ProfilePage = ({ params }: { params: { handle: string } }) => {
         ) : (
           !isPending &&
           freelancer && (
-            <WidgetProvider>
+            <WidgetProvider userId={freelancer.id}>
               <Profile
                 user={freelancer}
                 isMine={isMine}


### PR DESCRIPTION
# Connect widget grid to network

**Changes**
- Use a reducer for widget state and actions
- Add grid fallback
- Grid handles paste events
- Fail silently on layout mismatch to improve UX
- Add widget API v2 layer with image support
- Connect grid reducer to RQ network calls
- Enrich widgets when adding
- Silence msw logs
- Do not auto open sb and change port to 6300