### PR TITLE
Widgets V2 Fixes

### DIFF
--- a/src/app/splash.tsx
+++ b/src/app/splash.tsx
@@ -32,7 +32,7 @@ export const Splash: FC = () => {
   }, [ready, authenticated, router]);
 
   return (
-    <div className='flex w-full items-center justify-center'>
+    <div className='flex size-full items-center justify-center'>
       <MutedSorbetLogo className='animate-in slide-in-from-bottom-10 fade-in-10 duration-5000 size-44' />
     </div>
   );

--- a/src/app/v2/[handle]/components/profile.tsx
+++ b/src/app/v2/[handle]/components/profile.tsx
@@ -49,13 +49,13 @@ export const Profile = ({
             onEdit={() => setIsEditing(true)}
           />
           {/* TODO: Could/should these buttons auto open the privy via a query param? */}
-          {!isMine && (
-            <div className='flex gap-3'>
-              {isLoggedIn ? (
-                <Button variant='secondary' asChild>
-                  <Link href='/dashboard'>Back to Dashboard</Link>
-                </Button>
-              ) : (
+          <div className='flex gap-3'>
+            {isLoggedIn ? (
+              <Button variant='secondary' asChild>
+                <Link href='/dashboard'>Back to Dashboard</Link>
+              </Button>
+            ) : (
+              !isMine && (
                 <>
                   <Button variant='secondary' asChild>
                     <Link href='/signin'>Create my Sorbet</Link>
@@ -64,9 +64,9 @@ export const Profile = ({
                     <Link href='/signin'>Login</Link>
                   </Button>
                 </>
-              )}
-            </div>
-          )}
+              )
+            )}
+          </div>
         </div>
         {/* The right side of the profile. Should handle scroll itself */}
         {/* Container queries set this up to be responsive to the flex change on at 3xl. TODO: Still something isn't quite right */}

--- a/src/app/v2/[handle]/components/widget/widget.stories.tsx
+++ b/src/app/v2/[handle]/components/widget/widget.stories.tsx
@@ -22,9 +22,9 @@ const sizeConfigs = {
 
 const urls = {
   iconUrl:
-    'https://storage.googleapis.com/bkt-ph-prod-homepage-static-public/img/favicon.d8b7874261c3.ico',
+    'https://framerusercontent.com/images/vwqrWsyZbAoCnp6U2GM5Z4ncjwo.png',
   contentUrl:
-    'https://creatorspace.imgix.net/sites/ogimages/aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL2xleWVfYnVja2V0L3dwLWNvbnRlbnQvdXBsb2Fkcy80NWZhOGY0MS10b21hdG8tbW96ejItMjAyMDA4MTlfbGV5ZV9iLXNxdWFyZS1waXp6YS0yNTUtNzUuanBn.jpeg?width=600&height=600',
+    'https://framerusercontent.com/images/Ioch6MVHUWTPL65cNPDslY2ZMrs.png',
 };
 
 const meta = {

--- a/src/app/v2/[handle]/components/widget/widget.stories.tsx
+++ b/src/app/v2/[handle]/components/widget/widget.stories.tsx
@@ -3,28 +3,11 @@ import { Meta, StoryFn, StoryObj } from '@storybook/react';
 import { UrlType, UrlTypes } from './url-util';
 import { Widget } from './widget';
 
-const meta = {
-  title: 'Profile/v2/Widget',
-  component: Widget,
-  parameters: {
-    layout: 'centered',
-  },
-  decorators: [
-    (Story: StoryFn) => (
-      <div className='h-fit'>
-        <Story />
-      </div>
-    ),
-  ],
-} satisfies Meta<typeof Widget>;
-
-export default meta;
-type Story = StoryObj<typeof meta>;
-
-/** Helper to create a container with specific dimensions */
-const createSizeContainer = (width: number, height: number) => {
-  return (Story: StoryFn) => (
-    <div style={{ height: `${height}px`, width: `${width}px` }}>
+/** Helper to create a container based on size prop */
+const withSizeContainer = (Story: StoryFn, { args }: { args: any }) => {
+  const config = sizeConfigs[args.size as keyof typeof sizeConfigs];
+  return (
+    <div style={{ height: `${config.height}px`, width: `${config.width}px` }}>
       <Story />
     </div>
   );
@@ -37,8 +20,33 @@ const sizeConfigs = {
   D: { width: 390, height: 175 },
 } as const;
 
+const urls = {
+  iconUrl:
+    'https://storage.googleapis.com/bkt-ph-prod-homepage-static-public/img/favicon.d8b7874261c3.ico',
+  contentUrl:
+    'https://creatorspace.imgix.net/sites/ogimages/aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL2xleWVfYnVja2V0L3dwLWNvbnRlbnQvdXBsb2Fkcy80NWZhOGY0MS10b21hdG8tbW96ejItMjAyMDA4MTlfbGV5ZV9iLXNxdWFyZS1waXp6YS0yNTUtNzUuanBn.jpeg?width=600&height=600',
+};
+
+const meta = {
+  title: 'Profile/v2/Widget',
+  component: Widget,
+  parameters: {
+    layout: 'centered',
+  },
+  decorators: [
+    withSizeContainer,
+    (Story: StoryFn) => (
+      <div className='h-fit'>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof Widget>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
 export const Default: Story = {
-  decorators: [createSizeContainer(sizeConfigs.A.width, sizeConfigs.A.height)],
   args: {
     title: 'Widget',
     href: 'https://www.google.com',
@@ -47,7 +55,6 @@ export const Default: Story = {
 };
 
 export const A: Story = {
-  decorators: [createSizeContainer(sizeConfigs.A.width, sizeConfigs.A.height)],
   args: {
     ...Default.args,
     size: 'A',
@@ -55,7 +62,6 @@ export const A: Story = {
 };
 
 export const B: Story = {
-  decorators: [createSizeContainer(sizeConfigs.B.width, sizeConfigs.B.height)],
   args: {
     ...Default.args,
     size: 'B',
@@ -63,7 +69,6 @@ export const B: Story = {
 };
 
 export const C: Story = {
-  decorators: [createSizeContainer(sizeConfigs.C.width, sizeConfigs.C.height)],
   args: {
     ...Default.args,
     size: 'C',
@@ -71,7 +76,6 @@ export const C: Story = {
 };
 
 export const D: Story = {
-  decorators: [createSizeContainer(sizeConfigs.D.width, sizeConfigs.D.height)],
   args: {
     ...Default.args,
     size: 'D',
@@ -79,18 +83,13 @@ export const D: Story = {
 };
 
 export const WithIcon: Story = {
-  decorators: [createSizeContainer(sizeConfigs.A.width, sizeConfigs.A.height)],
   args: {
     ...Default.args,
-    iconUrl:
-      'https://storage.googleapis.com/bkt-ph-prod-homepage-static-public/img/favicon.d8b7874261c3.ico',
-    contentUrl:
-      'https://creatorspace.imgix.net/sites/ogimages/aHR0cHM6Ly9zdG9yYWdlLmdvb2dsZWFwaXMuY29tL2xleWVfYnVja2V0L3dwLWNvbnRlbnQvdXBsb2Fkcy80NWZhOGY0MS10b21hdG8tbW96ejItMjAyMDA4MTlfbGV5ZV9iLXNxdWFyZS1waXp6YS0yNTUtNzUuanBn.jpeg?width=600&height=600',
+    ...urls,
   },
 };
 
 export const Loading: Story = {
-  decorators: [createSizeContainer(sizeConfigs.A.width, sizeConfigs.A.height)],
   args: {
     ...Default.args,
     loading: true,

--- a/src/app/v2/[handle]/components/widget/widget.stories.tsx
+++ b/src/app/v2/[handle]/components/widget/widget.stories.tsx
@@ -89,6 +89,15 @@ export const WithIcon: Story = {
   },
 };
 
+export const WithIconAndLongTitle: Story = {
+  args: {
+    ...Default.args,
+    ...urls,
+    title:
+      'This is a long title that will wrap. This is a long title that will wrap. This is a long title that will wrap. This is a long title that will wrap. This is a long title that will wrap. This is a long title that will wrap. This is a long title that will wrap. This is a long title that will wrap.',
+  },
+};
+
 export const Loading: Story = {
   args: {
     ...Default.args,

--- a/src/app/v2/[handle]/components/widget/widget.stories.tsx
+++ b/src/app/v2/[handle]/components/widget/widget.stories.tsx
@@ -24,7 +24,7 @@ type Story = StoryObj<typeof meta>;
 /** Helper to create a container with specific dimensions */
 const createSizeContainer = (width: number, height: number) => {
   return (Story: StoryFn) => (
-    <div className={`h-[${height}px] w-[${width}px]`}>
+    <div style={{ height: `${height}px`, width: `${width}px` }}>
       <Story />
     </div>
   );

--- a/src/app/v2/[handle]/components/widget/widget.tsx
+++ b/src/app/v2/[handle]/components/widget/widget.tsx
@@ -81,7 +81,7 @@ export const Widget = ({
             {loading ? (
               <Skeleton
                 className={cn(
-                  size === 'A' && 'size-full',
+                  size === 'A' && 'aspect-[1200/630] w-full', // common og image aspect
                   size === 'C' && 'aspect-square w-full',
                   size === 'D' && 'aspect-square h-full'
                 )}
@@ -92,7 +92,7 @@ export const Widget = ({
                 alt={title}
                 className={cn(
                   'rounded-md object-cover',
-                  size === 'A' && 'aspect-[1200/630] size-full',
+                  size === 'A' && 'aspect-[1200/630] w-full', // common og image aspect
                   // B doesn't have a content image
                   size === 'C' && 'aspect-square w-full',
                   size === 'D' && 'aspect-square h-full'
@@ -127,7 +127,11 @@ const Icon: React.FC<React.ImgHTMLAttributes<HTMLImageElement>> = ({
     <div className='flex size-10 items-center justify-center rounded-md border p-2'>
       {src ? (
         <img
-          className={cn('size-full', className)}
+          className={cn(
+            'size-full',
+            'rounded-sm', // opt all favicons in to a litttle bit of rounding
+            className
+          )}
           src={src}
           alt='Icon for widget'
           {...rest}

--- a/src/app/v2/[handle]/components/widget/widget.tsx
+++ b/src/app/v2/[handle]/components/widget/widget.tsx
@@ -33,7 +33,7 @@ export const Widget = ({
     return (
       <ImageWidget
         contentUrl={contentUrl}
-        className='animate-in fade-in-0 zoom-in-0 max-h-[390px] max-w-[390px] duration-300'
+        className='animate-in fade-in-0 zoom-in-0 max-h-[390px] max-w-[390px] select-none duration-300'
         loading={loading}
       />
     );
@@ -44,7 +44,7 @@ export const Widget = ({
   return (
     <a
       className={cn(
-        'bg-card text-card-foreground flex flex-col overflow-hidden rounded-2xl border shadow-sm',
+        'bg-card text-card-foreground flex select-none flex-col overflow-hidden rounded-2xl border shadow-sm',
         size === 'D' && 'flex-row',
         'size-full max-h-[390px] max-w-[390px]',
         // Just a nice little touch when a widget is added

--- a/src/app/v2/[handle]/components/widget/widget.tsx
+++ b/src/app/v2/[handle]/components/widget/widget.tsx
@@ -57,7 +57,7 @@ export const Widget = ({
       draggable={false} // disable HTML5 dnd
       // TODO: Consider allowing dragging links to other programs with ondragstart="event.dataTransfer.setData('text/plain', href)">
     >
-      <CardHeader className='pb-10'>
+      <CardHeader className={cn('pb-10', size === 'D' && 'max-w-[50%]')}>
         {urlType ? (
           <SocialIcon type={urlType} />
         ) : loading ? (
@@ -92,7 +92,7 @@ export const Widget = ({
                 alt={title}
                 className={cn(
                   'rounded-md object-cover',
-                  size === 'A' && 'aspect-[342/230] size-full',
+                  size === 'A' && 'aspect-[1200/630] size-full',
                   // B doesn't have a content image
                   size === 'C' && 'aspect-square w-full',
                   size === 'D' && 'aspect-square h-full'


### PR DESCRIPTION
# Widgets V2 Fixes

**Changes**

- Render back to dashboard on your own profile
- Use og aspect on A size and fix D size crush
- opt all favicons in to a litttle bit of rounding 
- Widgets are select-none
- Fix splash page not being full size

Storybook
- fix string interpolation on widget stories
- automatic size containers for widget stories
- add long title story to widget
- widget stories use sorbet content
