### PR TITLE
Title Editing

### DIFF
--- a/src/api/widgets-v2/mock-widgets.ts
+++ b/src/api/widgets-v2/mock-widgets.ts
@@ -10,6 +10,7 @@ export const mockWidgetData: Record<string, WidgetData> = {
     contentUrl: 'https://picsum.photos/400/300?grayscale',
     href: 'https://picsum.photos/400/300?grayscale',
     iconUrl: 'https://picsum.photos/32/32?grayscale',
+    userTitle: 'User Title 1',
   },
   b: {
     id: 'b',
@@ -65,6 +66,7 @@ export const mockWidgetData: Record<string, WidgetData> = {
 export const sampleWidget: ApiWidget = {
   id: '123',
   title: 'Sample Widget',
+  userTitle: 'Sample User Title',
   iconUrl: 'https://placehold.co/32/orange/white',
   contentUrl: 'https://placehold.co/400/orange/white',
   href: 'https://example.com',
@@ -75,6 +77,8 @@ export const sampleWidget: ApiWidget = {
     { id: '123', x: 0, y: 0, w: 2, h: 2, breakpoint: 'sm' },
     { id: '123', x: 0, y: 0, w: 4, h: 4, breakpoint: 'lg' },
   ],
+  type: null,
+  custom: null,
 };
 
 export const mockWidgets: ApiWidget[] = Object.values(mockWidgetData).map(
@@ -84,7 +88,14 @@ export const mockWidgets: ApiWidget[] = Object.values(mockWidgetData).map(
     const lgLayout = sampleLayoutLg.find((l) => l.i === widget.id);
 
     return {
-      ...widget,
+      id: widget.id,
+      href: widget.href ?? null,
+      title: widget.title ?? null,
+      userTitle: widget.userTitle ?? null,
+      iconUrl: widget.iconUrl ?? null,
+      contentUrl: widget.contentUrl ?? null,
+      type: widget.type ?? null,
+      custom: null,
       createdAt: new Date(),
       updatedAt: new Date(),
       userId: '1',

--- a/src/api/widgets-v2/msw-handlers.ts
+++ b/src/api/widgets-v2/msw-handlers.ts
@@ -5,8 +5,6 @@ import { env } from '@/lib/env';
 import { mockWidgets, sampleWidget } from './mock-widgets';
 import { type CreateWidgetDto, type UpdateWidgetV2Dto } from './types';
 
-// 👇 These handlers were AI generated and have not been tested or used yet
-
 /**
  * Mock the data from the `/v2/widgets` POST endpoint for creating widgets
  */
@@ -66,17 +64,30 @@ export const mockUpdateWidgetHandler = http.put(
   `${env.NEXT_PUBLIC_SORBET_API_URL}/v2/widgets/:id`,
   async ({ params, request }) => {
     const { id } = params;
+    const previousWidget = mockWidgets.find((w) => w.id === id);
+    if (!previousWidget) {
+      return new HttpResponse(null, { status: 404 });
+    }
     const updateData = (await request.json()) as UpdateWidgetV2Dto;
     await delay();
 
     return HttpResponse.json({
-      ...sampleWidget,
+      ...previousWidget,
       id: id as string,
       title: updateData.title,
       contentUrl: updateData.contentUrl,
       custom: updateData.custom,
+      userTitle: updateData.userTitle,
       updatedAt: new Date(),
     });
+  }
+);
+
+export const mockUpdateWidgetHandlerFailure = http.put(
+  `${env.NEXT_PUBLIC_SORBET_API_URL}/v2/widgets/:id`,
+  async () => {
+    await delay();
+    return new HttpResponse(null, { status: 500 });
   }
 );
 

--- a/src/api/widgets-v2/types.ts
+++ b/src/api/widgets-v2/types.ts
@@ -38,25 +38,37 @@ export type UpdateLayoutsDto = {
   layouts: LayoutDto[];
 };
 
+/**
+ * Shape of the data used to update a widget
+ * Should match the UpdateWidgetV2Dto validator in the API
+ */
 export type UpdateWidgetV2Dto = {
-  /** The title of the widget */
+  /** The title of the widget. Set by enrichment. */
   title?: string;
 
   /** The content URL of the widget */
   contentUrl?: string;
 
+  /** The title a user sets for the widget. Use null to unset */
+  userTitle?: string | null;
+
   /** Any custom data for the widget */
   custom?: Record<string, unknown>;
 };
 
+/**
+ * Shape of a widget returned from the API
+ * Should match the prisma schema
+ */
 export type ApiWidget = {
   id: string;
-  href?: string;
-  title?: string;
-  iconUrl?: string;
-  contentUrl?: string;
-  type?: WidgetType;
-  custom?: Record<string, unknown>;
+  href: string | null;
+  title: string | null;
+  userTitle: string | null;
+  iconUrl: string | null;
+  contentUrl: string | null;
+  type: WidgetType | null;
+  custom: Record<string, unknown> | null;
   createdAt: Date;
   updatedAt: Date;
   userId: string;

--- a/src/app/[handle]/components/profile.stories.tsx
+++ b/src/app/[handle]/components/profile.stories.tsx
@@ -1,8 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
 
-import { mockUser } from '@/api/user';
-import { mockUserByHandleHandler } from '@/api/user';
-import { mockGetWidgetsHandler } from '@/api/widgets-v2';
+import { mockUser, mockUserByHandleHandler } from '@/api/user';
+import {
+  mockGetWidgetsHandler,
+  mockUpdateWidgetHandler,
+} from '@/api/widgets-v2';
 
 import { Profile } from './profile';
 import { WidgetProvider } from './widget/use-widget-context';
@@ -13,7 +15,14 @@ const meta = {
   component: Profile,
   parameters: {
     layout: 'fullscreen',
-    msw: [mockGetWidgetsHandler, mockUserByHandleHandler],
+    // Uncomment to use mock data. As is, this will hit the local api
+    msw: {
+      handlers: [
+        mockUserByHandleHandler,
+        mockGetWidgetsHandler,
+        mockUpdateWidgetHandler,
+      ],
+    },
   },
   decorators: [
     (Story) => (

--- a/src/app/[handle]/components/profile.tsx
+++ b/src/app/[handle]/components/profile.tsx
@@ -67,7 +67,12 @@ export const Profile = ({
       <div className='@3xl:flex-row @3xl:overflow-y-visible flex size-full flex-col items-center overflow-y-auto'>
         {/* Left part of the profile. desktop: full height and long enough to render profile details in desktop mode. */}
         {/* mobile: auto height and short enough to render profile details in mobile mode. */}
-        <div className='@3xl:h-full @3xl:min-w-96 flex w-[328px] flex-col justify-between gap-6 p-6'>
+        <div
+          className={cn(
+            '@3xl:h-full @3xl:min-w-96 flex w-[328px] flex-col justify-between gap-6 p-6',
+            'animate-in fade-in-0 duration-500'
+          )}
+        >
           <ProfileDetails
             user={user}
             isMine={isMine}

--- a/src/app/[handle]/components/widget/grid-config.ts
+++ b/src/app/[handle]/components/widget/grid-config.ts
@@ -53,13 +53,8 @@ export type WidgetData = {
   iconUrl?: string;
   id: string;
   title?: string;
+  userTitle?: string | null; // Null explicitly means no value
   type?: 'image';
-};
-
-// This is widget data augmented with display metadata.
-export type WidgetDataForDisplay = Omit<WidgetData, 'id'> & {
-  loading?: boolean;
-  size: WidgetSize;
 };
 
 // 👇 This is size config and calculations for the grid.

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -35,8 +35,14 @@ const ResponsiveGridLayout = WidthProvider(Responsive);
  * It will also break between a sm and lg size, based on it's own width using a container query.
  */
 export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
-  const { widgets, layouts, breakpoint, setBreakpoint, onLayoutChange } =
-    useWidgets();
+  const {
+    widgets,
+    layouts,
+    breakpoint,
+    setBreakpoint,
+    onLayoutChange,
+    updateWidget,
+  } = useWidgets();
   const width = gw(breakpoint);
 
   const draggedRef = useRef<boolean>(false);
@@ -87,7 +93,12 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
                 draggedRef={draggedRef}
                 hideControls={immutable}
               >
-                <Widget {...widget} size={s} />
+                <Widget
+                  {...widget}
+                  size={s}
+                  editable={!immutable}
+                  onUpdate={(data) => updateWidget(widget.id, data)}
+                />
               </RGLHandle>
             );
           })}

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -97,6 +97,7 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
                   {...widget}
                   size={s}
                   editable={!immutable}
+                  showPlaceholder={!immutable}
                   onUpdate={(data) => updateWidget(widget.id, data)}
                 />
               </RGLHandle>

--- a/src/app/[handle]/components/widget/social-icon.tsx
+++ b/src/app/[handle]/components/widget/social-icon.tsx
@@ -33,7 +33,7 @@ export const SocialIcon: React.FC<SocialIconProps> = ({
   ...rest
 }) => {
   const Icon = iconByUrlType[type];
-  return <Icon className={cn('size-10', className)} {...rest} />;
+  return <Icon className={cn('size-10 shrink-0', className)} {...rest} />;
 };
 
 const iconByUrlType: Record<

--- a/src/app/[handle]/components/widget/widget.stories.tsx
+++ b/src/app/[handle]/components/widget/widget.stories.tsx
@@ -44,6 +44,7 @@ export const Default: Story = {
     title: 'Widget',
     href: 'https://www.google.com',
     size: 'A',
+    editable: true,
   },
 };
 
@@ -95,6 +96,13 @@ export const Loading: Story = {
   args: {
     ...Default.args,
     loading: true,
+  },
+};
+
+export const Public: Story = {
+  args: {
+    ...Default.args,
+    editable: false,
   },
 };
 

--- a/src/app/[handle]/components/widget/widget.stories.tsx
+++ b/src/app/[handle]/components/widget/widget.stories.tsx
@@ -103,6 +103,7 @@ export const Public: Story = {
   args: {
     ...Default.args,
     editable: false,
+    showPlaceholder: false,
   },
 };
 

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -2,6 +2,7 @@ import { Link } from 'lucide-react';
 import React from 'react';
 import { parseURL } from 'ufo';
 
+import { InlineEdit } from '@/components/common/inline-edit/inline-edit';
 import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
@@ -10,6 +11,10 @@ import { WidgetDataForDisplay } from './grid-config';
 import { ImageWidget } from './image-widget';
 import { SocialIcon } from './social-icon';
 import { getUrlType } from './url-util';
+
+type WidgetProps = WidgetDataForDisplay & {
+  editable?: boolean;
+};
 
 /**
  * The most basic component to display a widget as an anchor tag styled as a card.
@@ -28,7 +33,8 @@ export const Widget = ({
   loading = false,
   type,
   size = 'A',
-}: WidgetDataForDisplay) => {
+  editable = false,
+}: WidgetProps) => {
   if (type === 'image') {
     return (
       <ImageWidget
@@ -41,15 +47,15 @@ export const Widget = ({
 
   const urlType = href && getUrlType(href);
 
+  const fallbackTitle = title || parseURL(href).host || href;
+
   return (
     <a
       className={cn(
         'bg-card text-card-foreground flex select-none flex-col overflow-hidden rounded-2xl border shadow-sm',
         size === 'D' && 'flex-row',
         'size-full max-h-[390px] max-w-[390px]',
-        // Just a nice little touch when a widget is added
-        // We would want to prevent this on first load, but maybe we don't even care if we are going to fade in the whole grid to hide the rgl transition?
-        'animate-in fade-in-0 zoom-in-0 duration-300'
+        'animate-in fade-in-0 zoom-in-0 duration-300' // Always have an enter animation. We hide the first one with a full grid fade anyway.
       )}
       href={href}
       target='_blank'
@@ -65,8 +71,17 @@ export const Widget = ({
         ) : (
           <Icon src={iconUrl} />
         )}
-        <CardTitle className='line-clamp-3 break-words text-sm font-normal'>
-          {title || parseURL(href).host || href}
+        <CardTitle className={cn('text-sm font-normal')}>
+          <InlineEdit
+            value={fallbackTitle || ''}
+            editable={editable}
+            placeholder={fallbackTitle || ''}
+            className={cn(
+              'line-clamp-3 break-words',
+              editable &&
+                'hover:bg-muted -ml-2 rounded-sm px-2 py-1 transition-colors duration-200'
+            )}
+          />
         </CardTitle>
       </CardHeader>
       {/* TODO: Perhaps you could extract all the size conditionals to this container? */}

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -7,13 +7,16 @@ import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 
-import { WidgetDataForDisplay } from './grid-config';
+import { WidgetData, WidgetSize } from './grid-config';
 import { ImageWidget } from './image-widget';
 import { SocialIcon } from './social-icon';
 import { getUrlType } from './url-util';
 
-type WidgetProps = WidgetDataForDisplay & {
+type WidgetProps = Omit<WidgetData, 'id'> & {
+  loading?: boolean;
+  size: WidgetSize;
   editable?: boolean;
+  onUpdate?: (data: Partial<WidgetData>) => void;
 };
 
 /**
@@ -28,12 +31,14 @@ type WidgetProps = WidgetDataForDisplay & {
 export const Widget = ({
   iconUrl,
   title,
+  userTitle,
   contentUrl,
   href,
   loading = false,
   type,
   size = 'A',
   editable = false,
+  onUpdate,
 }: WidgetProps) => {
   if (type === 'image') {
     return (
@@ -47,7 +52,9 @@ export const Widget = ({
 
   const urlType = href && getUrlType(href);
 
-  const fallbackTitle = title || parseURL(href).host || href;
+  // This is the title of the widget if the user has not explicitly set a title.
+  // If the user has set userTitle, it will be preferred. If they clear that, we will fall back to this.
+  const fallbackTitle = title || parseURL(href).host || href || '';
 
   return (
     <a
@@ -73,9 +80,12 @@ export const Widget = ({
         )}
         <CardTitle className={cn('text-sm font-normal')}>
           <InlineEdit
-            value={fallbackTitle || ''}
+            value={userTitle || fallbackTitle}
             editable={editable}
-            placeholder={fallbackTitle || ''}
+            onChange={(value) => {
+              onUpdate?.({ userTitle: value === '' ? null : value }); // If the user clears the title, set it to null to explicitly clear it
+            }}
+            placeholder={fallbackTitle}
             className={cn(
               'line-clamp-3 break-words',
               editable &&

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -70,7 +70,7 @@ export const Widget = ({
       draggable={false} // disable HTML5 dnd
       // TODO: Consider allowing dragging links to other programs with ondragstart="event.dataTransfer.setData('text/plain', href)">
     >
-      <CardHeader className={cn('pb-10', size === 'D' && 'max-w-[50%]')}>
+      <CardHeader className={cn('space-y-1', size === 'D' && 'max-w-[60%]')}>
         {urlType ? (
           <SocialIcon type={urlType} />
         ) : loading ? (
@@ -98,7 +98,7 @@ export const Widget = ({
       <CardContent
         className={cn(
           'flex flex-1 items-end justify-end',
-          size === 'D' && 'pt-6'
+          size === 'D' && 'pl-0 pt-6'
         )}
       >
         {size !== 'B' && (

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -17,6 +17,7 @@ type WidgetProps = Omit<WidgetData, 'id'> & {
   size: WidgetSize;
   editable?: boolean;
   onUpdate?: (data: Partial<WidgetData>) => void;
+  showPlaceholder?: boolean;
 };
 
 /**
@@ -39,6 +40,7 @@ export const Widget = ({
   size = 'A',
   editable = false,
   onUpdate,
+  showPlaceholder = true,
 }: WidgetProps) => {
   if (type === 'image') {
     return (
@@ -124,13 +126,15 @@ export const Widget = ({
                 )}
               />
             ) : (
-              <ContentPlaceholder
-                className={cn(
-                  size === 'A' && 'aspect-[1200/630] w-full',
-                  size === 'C' && 'aspect-square w-full',
-                  size === 'D' && 'aspect-square h-full'
-                )}
-              />
+              showPlaceholder && (
+                <ContentPlaceholder
+                  className={cn(
+                    size === 'A' && 'aspect-[1200/630] w-full',
+                    size === 'C' && 'aspect-square w-full',
+                    size === 'D' && 'aspect-square h-full'
+                  )}
+                />
+              )
             )}
           </>
         )}

--- a/src/app/[handle]/page.stories.tsx
+++ b/src/app/[handle]/page.stories.tsx
@@ -1,7 +1,10 @@
 import { Meta, StoryObj } from '@storybook/react';
 
 import { mockUserByHandleHandler } from '@/api/user';
-import { mockGetWidgetsHandler } from '@/api/widgets-v2';
+import {
+  mockGetWidgetsHandler,
+  mockUpdateWidgetHandler,
+} from '@/api/widgets-v2';
 
 import ProfilePage from './page';
 
@@ -12,8 +15,13 @@ const meta = {
   component: ProfilePage,
   parameters: {
     layout: 'fullscreen',
+    // Uncomment to use mock data. As is, this will hit the local api
     msw: {
-      handlers: [mockUserByHandleHandler, mockGetWidgetsHandler], // Uncomment to use mock data. As is, this will hit the local api
+      handlers: [
+        mockUserByHandleHandler,
+        mockGetWidgetsHandler,
+        mockUpdateWidgetHandler,
+      ],
     },
   },
   args: {

--- a/src/components/common/inline-edit/inline-edit.stories.tsx
+++ b/src/components/common/inline-edit/inline-edit.stories.tsx
@@ -1,0 +1,49 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+import { InlineEdit } from './inline-edit';
+
+const meta = {
+  title: 'Components/common/InlineEdit',
+  component: InlineEdit,
+  parameters: {
+    layout: 'centered',
+  },
+  tags: ['autodocs'],
+  decorators: [
+    (Story) => (
+      <div className='border-border w-40 rounded-md border-2 border-dashed p-2'>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof InlineEdit>;
+
+export default meta;
+type Story = StoryObj<typeof InlineEdit>;
+
+export const Default: Story = {
+  args: {
+    value: 'Click to edit',
+    onChange: fn(),
+    editable: true,
+    placeholder: 'Enter text',
+  },
+};
+
+export const ReadOnly: Story = {
+  args: {
+    value: 'This text cannot be edited',
+    onChange: fn(),
+    editable: false,
+  },
+};
+
+export const Empty: Story = {
+  args: {
+    value: '',
+    onChange: fn(),
+    editable: true,
+    placeholder: 'Empty state with placeholder',
+  },
+};

--- a/src/components/common/inline-edit/inline-edit.tsx
+++ b/src/components/common/inline-edit/inline-edit.tsx
@@ -1,0 +1,81 @@
+import React, { useState } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface InlineEditProps {
+  /** The current value to display/edit */
+  value: string;
+  /** Callback when the value changes and is saved */
+  onChange?: (value: string) => void;
+  /** Whether editing is allowed */
+  editable?: boolean;
+  /** Optional placeholder text */
+  placeholder?: string;
+  /** Optional className for the container */
+  className?: string;
+}
+
+export const InlineEdit = ({
+  value,
+  onChange,
+  editable = false,
+  placeholder,
+  className,
+}: InlineEditProps): JSX.Element => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [editValue, setEditValue] = useState(value);
+
+  const handleBlur = () => {
+    setIsEditing(false);
+    if (onChange && editValue !== value) {
+      onChange(editValue);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      (e.target as HTMLInputElement).blur();
+    } else if (e.key === 'Escape') {
+      setEditValue(value);
+      setIsEditing(false);
+    }
+  };
+
+  const handleClick = (e: React.MouseEvent) => {
+    if (editable) {
+      e.preventDefault();
+      e.stopPropagation();
+      setIsEditing(true);
+    }
+  };
+
+  // Update local state when prop value changes
+  React.useEffect(() => {
+    setEditValue(value);
+  }, [value]);
+
+  return (
+    <div
+      onClick={handleClick}
+      className={cn(editable && 'cursor-text', className)}
+    >
+      {editable && isEditing ? (
+        <input
+          value={editValue}
+          onChange={(e) => setEditValue(e.target.value)}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          placeholder={placeholder}
+          autoFocus
+          className='w-full border-none bg-transparent p-0 text-sm font-normal outline-none'
+        />
+      ) : (
+        <span className='text-sm font-normal'>
+          {value || (
+            <span className='text-muted-foreground'>{placeholder}</span>
+          )}
+        </span>
+      )}
+    </div>
+  );
+};


### PR DESCRIPTION
**Changes**

- Make titles in widgets editable
- Add an inline editable component and render in widget
- The widget grid kicks off network updates from this callback
- Update MSW handlers to be more realistic
- Update ApiWidget to use nulls instead of undefined. And then shim conversion to UI types
- Fix some minor styles for D widgets
- add more mocking to stories
- fade in left side of profile