### PR TITLE
[SRBT-433] Implement Mobile Switch

### DIFF
--- a/.vscode/typescriptreact.code-snippets
+++ b/.vscode/typescriptreact.code-snippets
@@ -189,5 +189,29 @@
     "body": [
       "logger({ ${1:${CLIPBOARD}} }, '${TM_FILENAME} line ${TM_LINE_NUMBER}')"
     ]
+  },
+  "Storybook": {
+    "prefix": "sb",
+    "body": [
+      "import { Meta, StoryObj } from '@storybook/react';",
+      "import { fn } from '@storybook/test';",
+      "",
+      "import { ${1:${TM_FILENAME_BASE/(.*?)[-.]stories$/$1/}} } from './${1:${TM_FILENAME_BASE/(.*?)[-.]stories$/$1/}}';",
+      "",
+      "const meta = {",
+      "  title: '${2:Component}/${1:${TM_FILENAME_BASE/(.*?)[-.]stories$/$1/}}',",
+      "  component: ${1:${TM_FILENAME_BASE/(.*?)[-.]stories$/$1/}},",
+      "  parameters: {",
+      "    layout: 'centered',",
+      "  },",
+      "} satisfies Meta<typeof ${1:${TM_FILENAME_BASE/(.*?)[-.]stories$/$1/}}>;",
+      "",
+      "export default meta;",
+      "",
+      "type Story = StoryObj<typeof ${1:${TM_FILENAME_BASE/(.*?)[-.]stories$/$1/}}>;",
+      "",
+      "export const Default: Story = {};",
+      ""
+    ]
   }
 }

--- a/src/app/[handle]/components/artificial-mobile.stories.tsx
+++ b/src/app/[handle]/components/artificial-mobile.stories.tsx
@@ -1,0 +1,65 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { ArtificialMobile } from './artificial-mobile';
+
+const meta = {
+  title: 'Profile/ArtificialMobile',
+  component: ArtificialMobile,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  argTypes: {
+    children: {
+      table: {
+        disable: true,
+      },
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className='h-screen w-screen'>
+        <Story />
+      </div>
+    ),
+  ],
+} satisfies Meta<typeof ArtificialMobile>;
+
+export default meta;
+
+type Story = StoryObj<typeof ArtificialMobile>;
+
+export const Default: Story = {
+  args: {
+    children: (
+      <div className='bg-sorbet/20 flex size-full flex-col items-center justify-center'>
+        Hello world
+      </div>
+    ),
+  },
+};
+
+export const Mobile: Story = {
+  args: {
+    ...Default.args,
+    isMobile: true,
+  },
+};
+
+export const ShowMotion: Story = {
+  args: {
+    ...Default.args,
+    isMobile: true,
+    duration: 2,
+  },
+};
+
+export const WithScroll: Story = {
+  args: {
+    ...Default.args,
+    children: (
+      <div className='bg-sorbet/20 flex size-full h-[1000px] flex-col items-center justify-center'>
+        Hello world
+      </div>
+    ),
+  },
+};

--- a/src/app/[handle]/components/artificial-mobile.stories.tsx
+++ b/src/app/[handle]/components/artificial-mobile.stories.tsx
@@ -45,6 +45,13 @@ export const Mobile: Story = {
   },
 };
 
+export const NoFlash: Story = {
+  args: {
+    ...Default.args,
+    flashDuration: false,
+  },
+};
+
 export const ShowMotion: Story = {
   args: {
     ...Default.args,

--- a/src/app/[handle]/components/artificial-mobile.tsx
+++ b/src/app/[handle]/components/artificial-mobile.tsx
@@ -20,9 +20,9 @@ export const ArtificialMobile = ({
 }: {
   /** Whether the container is in mobile mode. */
   isMobile?: boolean;
-  /** Duration of the transition animation. Use `0` to disable. Defaults to `0.3` */
+  /** Duration of the transition animation in seconds. Use `0` to disable. Defaults to `0.3` */
   duration?: number;
-  /** Duration of the flash animation. Use `0` to disable. Defaults to `duration * 2` */
+  /** Duration of the flash animation in seconds. Use `0` to disable. Defaults to `duration * 2.1` */
   flashDuration?: number;
   children?: React.ReactNode;
   className?: string;
@@ -32,7 +32,7 @@ export const ArtificialMobile = ({
   const flashControls = useAnimationControls();
 
   const mobileWidth = '380px';
-  const flashDuration = props.flashDuration ?? duration * 2;
+  const flashDuration = props.flashDuration ?? duration * 2.1;
 
   // Track changes to isMobile and trigger flash animation when it changes (but not on mount)
   useEffect(() => {
@@ -91,7 +91,7 @@ export const ArtificialMobile = ({
           isMobile && 'border-muted overflow-clip border-2 py-6 shadow-sm'
         )}
         style={{ transitionDuration: `${duration}s` }}
-        initial={isMobile ? 'mobile' : 'desktop'}
+        initial={false}
         animate={isMobile ? 'mobile' : 'desktop'}
         variants={containerVariants}
         transition={{ duration, ease: 'easeOut' }}
@@ -99,7 +99,7 @@ export const ArtificialMobile = ({
         {/* Full size container handles the flash during transition. */}
         <motion.div
           className='size-full'
-          initial='initial'
+          initial={false}
           animate={flashControls}
           variants={flashVariants}
         >

--- a/src/app/[handle]/components/artificial-mobile.tsx
+++ b/src/app/[handle]/components/artificial-mobile.tsx
@@ -76,7 +76,7 @@ export const ArtificialMobile = ({
     <div
       className={cn(
         'bg-muted/70 size-full transition-[padding]',
-        isMobile && 'py-4 pb-28',
+        isMobile && 'py-12',
         className
       )}
       style={{ transitionDuration: `${duration}s` }}
@@ -100,7 +100,7 @@ export const ArtificialMobile = ({
           animate={flashControls}
           variants={flashVariants}
         >
-          {/* Scroll area only in mobile mode */}
+          {/* Scroll area only in mobile mode (TODO: This causes rerenders, is that ok?) */}
           {isMobile ? (
             <ScrollArea className='size-full'>{children}</ScrollArea>
           ) : (

--- a/src/app/[handle]/components/artificial-mobile.tsx
+++ b/src/app/[handle]/components/artificial-mobile.tsx
@@ -31,7 +31,7 @@ export const ArtificialMobile = ({
   const prevIsMobile = useRef(isMobile);
   const flashControls = useAnimationControls();
 
-  const mobileWidth = '448px';
+  const mobileWidth = '380px';
   const flashDuration = props.flashDuration ?? duration * 2;
 
   // Track changes to isMobile and trigger flash animation when it changes (but not on mount)
@@ -54,7 +54,7 @@ export const ArtificialMobile = ({
     mobile: {
       width: mobileWidth,
       borderWidth: '2px',
-      borderRadius: '48px',
+      borderRadius: '40px',
     },
     desktop: {
       width: '100%',
@@ -88,7 +88,7 @@ export const ArtificialMobile = ({
       <motion.div
         className={cn(
           'bg-background mx-auto size-full border-transparent transition-[border-color]',
-          isMobile && 'border-muted overflow-clip border-2 shadow-sm '
+          isMobile && 'border-muted overflow-clip border-2 py-6 shadow-sm'
         )}
         style={{ transitionDuration: `${duration}s` }}
         initial={isMobile ? 'mobile' : 'desktop'}

--- a/src/app/[handle]/components/artificial-mobile.tsx
+++ b/src/app/[handle]/components/artificial-mobile.tsx
@@ -13,17 +13,17 @@ import { cn } from '@/lib/utils';
  */
 export const ArtificialMobile = ({
   isMobile,
-  duration = 0.3,
+  duration = 0.4,
   children,
   className,
   ...props
 }: {
   /** Whether the container is in mobile mode. */
   isMobile?: boolean;
-  /** Duration of the transition animation in seconds. Use `0` to disable. Defaults to `0.3` */
+  /** Duration of the transition animation in seconds. Use `0` to disable. Defaults to `0.4` */
   duration?: number;
   /** Duration of the flash animation in seconds. Use `0` to disable. Defaults to `duration * 2.1` */
-  flashDuration?: number;
+  flashDuration?: number | false;
   children?: React.ReactNode;
   className?: string;
 }) => {
@@ -36,6 +36,10 @@ export const ArtificialMobile = ({
 
   // Track changes to isMobile and trigger flash animation when it changes (but not on mount)
   useEffect(() => {
+    if (flashDuration === false) {
+      return;
+    }
+
     if (isInitialMount.current) {
       isInitialMount.current = false;
       return;
@@ -47,19 +51,19 @@ export const ArtificialMobile = ({
     }
 
     prevIsMobile.current = isMobile;
-  }, [isMobile, flashControls]);
+  }, [isMobile, flashControls, flashDuration]);
 
   // Animation variants
   const containerVariants = {
     mobile: {
-      width: mobileWidth,
       borderWidth: '2px',
       borderRadius: '40px',
+      borderColor: 'hsl(var(--border))',
     },
     desktop: {
-      width: '100%',
       borderWidth: '0px',
       borderRadius: '0px',
+      borderColor: 'transparent',
     },
   };
 
@@ -78,23 +82,22 @@ export const ArtificialMobile = ({
     // Root full size container which transitions the padding
     <div
       className={cn(
-        'bg-muted/70 size-full transition-[padding]',
+        'bg-muted/70 flex size-full flex-col items-center justify-center',
         isMobile && 'py-12',
         className
       )}
-      style={{ transitionDuration: `${duration}s` }}
     >
       {/* Artificial Mobile container transitions everything else */}
       <motion.div
         className={cn(
-          'bg-background mx-auto size-full border-transparent transition-[border-color]',
-          isMobile && 'border-muted overflow-clip border-2 py-6 shadow-sm'
+          'bg-background size-full overflow-clip',
+          isMobile && 'max-h-[48rem] w-[28rem] py-8 shadow-sm'
         )}
-        style={{ transitionDuration: `${duration}s` }}
+        layout
         initial={false}
         animate={isMobile ? 'mobile' : 'desktop'}
         variants={containerVariants}
-        transition={{ duration, ease: 'easeOut' }}
+        transition={{ duration, ease: 'easeInOut' }}
       >
         {/* Full size container handles the flash during transition. */}
         <motion.div

--- a/src/app/[handle]/components/artificial-mobile.tsx
+++ b/src/app/[handle]/components/artificial-mobile.tsx
@@ -105,7 +105,9 @@ export const ArtificialMobile = ({
         >
           {/* Scroll area only in mobile mode (TODO: This causes rerenders, is that ok?) */}
           {isMobile ? (
-            <ScrollArea className='size-full'>{children}</ScrollArea>
+            <ScrollArea className='size-full [mask-image:linear-gradient(to_bottom,transparent,black_32px,black_calc(100%-32px),transparent)]'>
+              {children}
+            </ScrollArea>
           ) : (
             children
           )}

--- a/src/app/[handle]/components/artificial-mobile.tsx
+++ b/src/app/[handle]/components/artificial-mobile.tsx
@@ -1,0 +1,109 @@
+import { ScrollArea } from '@/components/ui/scroll-area';
+import { cn } from '@/lib/utils';
+import { motion, useAnimationControls, Variant } from 'framer-motion';
+import { useEffect, useRef } from 'react';
+
+/**
+ * Fills width and height and renders children inside.
+ *
+ * When `isMobile` is true, transitions to an artificial mobile container and renders children inside.
+ *
+ * TODO: Consider a top and bottom safe area with a feathered edge to more realistically show mobile and fox scrollbar cut
+ */
+export const ArtificialMobile = ({
+  isMobile,
+  duration = 0.3,
+  children,
+  ...props
+}: {
+  isMobile?: boolean;
+  children?: React.ReactNode;
+  duration?: number;
+  flashDuration?: number;
+}) => {
+  const isInitialMount = useRef(true);
+  const prevIsMobile = useRef(isMobile);
+  const flashControls = useAnimationControls();
+
+  const mobileWidth = '448px';
+  const flashDuration = props.flashDuration ?? duration * 2;
+
+  // Track changes to isMobile and trigger flash animation when it changes (but not on mount)
+  useEffect(() => {
+    if (isInitialMount.current) {
+      isInitialMount.current = false;
+      return;
+    }
+
+    if (prevIsMobile.current !== isMobile) {
+      // Trigger flash animation
+      flashControls.start('flash');
+    }
+
+    prevIsMobile.current = isMobile;
+  }, [isMobile, flashControls]);
+
+  // Animation variants
+  const containerVariants = {
+    mobile: {
+      width: mobileWidth,
+      borderWidth: '2px',
+      borderRadius: '48px',
+    },
+    desktop: {
+      width: '100%',
+      borderWidth: '0px',
+      borderRadius: '0px',
+    },
+  };
+
+  const flashVariants = {
+    initial: { opacity: 1 },
+    flash: {
+      opacity: [1, 0, 0, 1],
+      transition: {
+        duration: flashDuration,
+        times: [0, 0, 0.7, 1],
+      },
+    },
+  };
+
+  return (
+    // Root full size container which transitions the padding.
+    <div
+      className={cn(
+        'bg-muted/70 size-full transition-[padding]',
+        isMobile && 'py-4 pb-28'
+      )}
+      style={{ transitionDuration: `${duration}s` }}
+    >
+      {/* Artificial Mobile container transitions everything else */}
+      <motion.div
+        className={cn(
+          'bg-background mx-auto size-full border-transparent transition-[border-color]',
+          isMobile && 'border-muted overflow-clip border-2 shadow-sm '
+        )}
+        style={{ transitionDuration: `${duration}s` }}
+        initial={isMobile ? 'mobile' : 'desktop'}
+        animate={isMobile ? 'mobile' : 'desktop'}
+        variants={containerVariants}
+        transition={{ duration, ease: 'easeOut' }}
+      >
+        {/* Full size container handles the flash during transition. */}
+        <motion.div
+          className='size-full'
+          initial='initial'
+          animate={flashControls}
+          variants={flashVariants}
+        >
+          {/* Scroll area only in mobile mode */}
+          {isMobile ? (
+            <ScrollArea className='size-full'>{children}</ScrollArea>
+          ) : (
+            children
+          )}
+        </motion.div>
+      </motion.div>
+    </div>
+  );
+};

--- a/src/app/[handle]/components/artificial-mobile.tsx
+++ b/src/app/[handle]/components/artificial-mobile.tsx
@@ -1,7 +1,8 @@
+import { motion, useAnimationControls } from 'framer-motion';
+import { useEffect, useRef } from 'react';
+
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { cn } from '@/lib/utils';
-import { motion, useAnimationControls, Variant } from 'framer-motion';
-import { useEffect, useRef } from 'react';
 
 /**
  * Fills width and height and renders children inside.
@@ -14,12 +15,14 @@ export const ArtificialMobile = ({
   isMobile,
   duration = 0.3,
   children,
+  className,
   ...props
 }: {
   isMobile?: boolean;
   children?: React.ReactNode;
   duration?: number;
   flashDuration?: number;
+  className?: string;
 }) => {
   const isInitialMount = useRef(true);
   const prevIsMobile = useRef(isMobile);
@@ -69,11 +72,12 @@ export const ArtificialMobile = ({
   };
 
   return (
-    // Root full size container which transitions the padding.
+    // Root full size container which transitions the padding
     <div
       className={cn(
         'bg-muted/70 size-full transition-[padding]',
-        isMobile && 'py-4 pb-28'
+        isMobile && 'py-4 pb-28',
+        className
       )}
       style={{ transitionDuration: `${duration}s` }}
     >

--- a/src/app/[handle]/components/artificial-mobile.tsx
+++ b/src/app/[handle]/components/artificial-mobile.tsx
@@ -18,10 +18,13 @@ export const ArtificialMobile = ({
   className,
   ...props
 }: {
+  /** Whether the container is in mobile mode. */
   isMobile?: boolean;
-  children?: React.ReactNode;
+  /** Duration of the transition animation. Use `0` to disable. Defaults to `0.3` */
   duration?: number;
+  /** Duration of the flash animation. Use `0` to disable. Defaults to `duration * 2` */
   flashDuration?: number;
+  children?: React.ReactNode;
   className?: string;
 }) => {
   const isInitialMount = useRef(true);

--- a/src/app/[handle]/components/artificial-mobile.tsx
+++ b/src/app/[handle]/components/artificial-mobile.tsx
@@ -103,7 +103,7 @@ export const ArtificialMobile = ({
           animate={flashControls}
           variants={flashVariants}
         >
-          {/* Scroll area only in mobile mode (TODO: This causes rerenders, is that ok?) */}
+          {/* Scroll area only in mobile mode (Note: this causes a remount of children. If this is an issue, take a style approach) */}
           {isMobile ? (
             <ScrollArea className='size-full [mask-image:linear-gradient(to_bottom,transparent,black_32px,black_calc(100%-32px),transparent)]'>
               {children}

--- a/src/app/[handle]/components/artificial-mobile.tsx
+++ b/src/app/[handle]/components/artificial-mobile.tsx
@@ -31,7 +31,6 @@ export const ArtificialMobile = ({
   const prevIsMobile = useRef(isMobile);
   const flashControls = useAnimationControls();
 
-  const mobileWidth = '380px';
   const flashDuration = props.flashDuration ?? duration * 2.1;
 
   // Track changes to isMobile and trigger flash animation when it changes (but not on mount)

--- a/src/app/[handle]/components/control-bar/control-bar.stories.tsx
+++ b/src/app/[handle]/components/control-bar/control-bar.stories.tsx
@@ -22,8 +22,8 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {};
 
-export const Mobile: Story = {
+export const Disabled: Story = {
   args: {
-    isMobile: true,
+    isDisabled: true,
   },
 };

--- a/src/app/[handle]/components/control-bar/control-bar.stories.tsx
+++ b/src/app/[handle]/components/control-bar/control-bar.stories.tsx
@@ -10,9 +10,11 @@ const meta = {
     layout: 'centered',
   },
   args: {
+    isMobile: false,
     onAddImage: fn(),
     onAddLink: fn(),
     onShare: fn(),
+    onIsMobileChange: fn(),
   },
 } satisfies Meta<typeof ControlBar>;
 
@@ -25,5 +27,11 @@ export const Default: Story = {};
 export const Disabled: Story = {
   args: {
     isDisabled: true,
+  },
+};
+
+export const WithoutMobileSwitch: Story = {
+  args: {
+    onIsMobileChange: undefined,
   },
 };

--- a/src/app/[handle]/components/control-bar/control-bar.tsx
+++ b/src/app/[handle]/components/control-bar/control-bar.tsx
@@ -33,7 +33,7 @@ export const ControlBar = ({
   onAddImage,
   onAddLink,
   onShare,
-  isMobile,
+  isDisabled,
 }: {
   /** Called when a valid image is added */
   onAddImage?: (image: File) => void;
@@ -41,8 +41,8 @@ export const ControlBar = ({
   onAddLink?: (link: string) => void;
   /** Called when the share button is clicked */
   onShare?: () => void;
-  /** Whether the control bar is in mobile mode */
-  isMobile?: boolean;
+  /** Whether the control bar is disabled */
+  isDisabled?: boolean;
 }) => {
   const form = useForm<FormSchema>({
     resolver: zodResolver(schema),
@@ -74,8 +74,8 @@ export const ControlBar = ({
               Share
             </Button>
             <Separator orientation='vertical' className='h-9' />
-            {isMobile ? (
-              <MobilePopoverButton />
+            {isDisabled ? (
+              <DisabledPopoverButton />
             ) : (
               <div className='flex items-center gap-2'>
                 <Tooltip>
@@ -140,7 +140,7 @@ const schema = z.object({
 type FormSchema = z.infer<typeof schema>;
 
 // Local component rendering a popover to let users know that editing links is desktop only
-const MobilePopoverButton = () => {
+const DisabledPopoverButton = () => {
   return (
     <Popover>
       <PopoverTrigger asChild>

--- a/src/app/[handle]/components/control-bar/control-bar.tsx
+++ b/src/app/[handle]/components/control-bar/control-bar.tsx
@@ -33,6 +33,8 @@ export const ControlBar = ({
   onAddImage,
   onAddLink,
   onShare,
+  isMobile,
+  onIsMobileChange,
   isDisabled,
 }: {
   /** Called when a valid image is added */
@@ -43,6 +45,11 @@ export const ControlBar = ({
   onShare?: () => void;
   /** Whether the control bar is disabled */
   isDisabled?: boolean;
+
+  /** Whether the control bar is in mobile mode */
+  isMobile?: boolean;
+  /** Called when the mobile mode is toggled. Omit to hide the mobile switch */
+  onIsMobileChange?: (isMobile: boolean) => void;
 }) => {
   const form = useForm<FormSchema>({
     resolver: zodResolver(schema),
@@ -64,6 +71,8 @@ export const ControlBar = ({
     setIsPopoverOpen(open);
     !open && reset();
   };
+
+  const showMobileSwitch = onIsMobileChange !== undefined;
 
   return (
     <Popover open={isPopoverOpen} onOpenChange={handlePopoverOpenChange}>
@@ -124,8 +133,15 @@ export const ControlBar = ({
                 <AddImageButton onAdd={onAddImage} />
               </div>
             )}
-            <Separator orientation='vertical' className='h-9' />
-            <MobileSwitch />
+            {showMobileSwitch && (
+              <>
+                <Separator orientation='vertical' className='h-9' />
+                <MobileSwitch
+                  isMobile={Boolean(isMobile)}
+                  onIsMobileChange={onIsMobileChange}
+                />
+              </>
+            )}
           </CardContent>
         </Card>
       </PopoverAnchor>

--- a/src/app/[handle]/components/control-bar/control-bar.tsx
+++ b/src/app/[handle]/components/control-bar/control-bar.tsx
@@ -85,7 +85,7 @@ export const ControlBar = ({
               !showMobileSwitch && 'pr-3' // concentric rounding
             )}
           >
-            <Button variant='sorbet' size='sm' onClick={onShare}>
+            <Button variant='sorbet' size='sm' effect='shine' onClick={onShare}>
               Share
             </Button>
             <Separator orientation='vertical' className='h-9' />

--- a/src/app/[handle]/components/control-bar/control-bar.tsx
+++ b/src/app/[handle]/components/control-bar/control-bar.tsx
@@ -20,6 +20,7 @@ import { Separator } from '@/components/ui/separator';
 import { TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Tooltip } from '@/components/ui/tooltip';
 import { useAfter } from '@/hooks/use-after';
+import { cn } from '@/lib/utils';
 
 import { MobileSwitch } from '../mobile-switch/mobile-switch';
 import { AddImageButton } from './add-image-button';
@@ -78,7 +79,12 @@ export const ControlBar = ({
     <Popover open={isPopoverOpen} onOpenChange={handlePopoverOpenChange}>
       <PopoverAnchor asChild>
         <Card className='h-fit rounded-xl shadow-lg'>
-          <CardContent className='flex h-full items-center justify-between gap-4 p-2'>
+          <CardContent
+            className={cn(
+              'flex h-full items-center justify-between gap-4 p-2',
+              !showMobileSwitch && 'pr-3' // concentric rounding
+            )}
+          >
             <Button variant='sorbet' size='sm' onClick={onShare}>
               Share
             </Button>

--- a/src/app/[handle]/components/control-bar/control-bar.tsx
+++ b/src/app/[handle]/components/control-bar/control-bar.tsx
@@ -21,6 +21,7 @@ import { TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import { Tooltip } from '@/components/ui/tooltip';
 import { useAfter } from '@/hooks/use-after';
 
+import { MobileSwitch } from '../mobile-switch/mobile-switch';
 import { AddImageButton } from './add-image-button';
 
 // TODO: Read the clipboard and if it's a url, show a paste button
@@ -68,9 +69,9 @@ export const ControlBar = ({
     <Popover open={isPopoverOpen} onOpenChange={handlePopoverOpenChange}>
       <PopoverAnchor asChild>
         <Card className='h-fit rounded-xl shadow-lg'>
-          <CardContent className='flex h-full items-center justify-between gap-4 p-2 pr-3'>
+          <CardContent className='flex h-full items-center justify-between gap-4 p-2'>
             <Button variant='sorbet' size='sm' onClick={onShare}>
-              Share profile
+              Share
             </Button>
             <Separator orientation='vertical' className='h-9' />
             {isMobile ? (
@@ -123,6 +124,8 @@ export const ControlBar = ({
                 <AddImageButton onAdd={onAddImage} />
               </div>
             )}
+            <Separator orientation='vertical' className='h-9' />
+            <MobileSwitch />
           </CardContent>
         </Card>
       </PopoverAnchor>

--- a/src/app/[handle]/components/mobile-switch/animated-tabs.stories.tsx
+++ b/src/app/[handle]/components/mobile-switch/animated-tabs.stories.tsx
@@ -1,0 +1,44 @@
+import { useArgs } from '@storybook/preview-api';
+import { Meta, StoryObj } from '@storybook/react';
+import { Moon, Sun } from 'lucide-react';
+
+import { AnimatedTabs } from './animated-tabs';
+
+const meta = {
+  title: 'Build UI/Animated Tabs',
+  component: AnimatedTabs,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof AnimatedTabs>;
+
+export default meta;
+
+type Story = StoryObj<typeof AnimatedTabs>;
+
+export const Default: Story = {
+  args: {
+    tabs: [
+      {
+        id: 'sun',
+        icon: <Sun />,
+        tooltip: 'Light mode',
+      },
+      {
+        id: 'moon',
+        icon: <Moon />,
+        tooltip: 'Dark mode',
+      },
+    ],
+  },
+  render: (args) => {
+    const [{ selectedTab }, setArgs] = useArgs();
+    return (
+      <AnimatedTabs
+        {...args}
+        selectedTab={selectedTab}
+        onSelectTab={(tab) => setArgs({ selectedTab: tab })}
+      />
+    );
+  },
+};

--- a/src/app/[handle]/components/mobile-switch/animated-tabs.tsx
+++ b/src/app/[handle]/components/mobile-switch/animated-tabs.tsx
@@ -1,0 +1,71 @@
+import { motion } from 'framer-motion';
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+import { cn } from '@/lib/utils';
+
+type Tab = {
+  id: string;
+  icon: React.ReactNode;
+  tooltip?: string;
+};
+
+/**
+ * An animated tab switch based on [Build UI's AnimatedTabs](https://buildui.com/recipes/animated-tabs).
+ * - built with Framer Motion's `layoutId` and `mix-blend-difference`
+ * TODO: Remove hardcoded colors
+ */
+export const AnimatedTabs = ({
+  tabs,
+  selectedTab: selectedTabProp,
+  onSelectTab,
+}: {
+  tabs: Tab[];
+  selectedTab: string;
+  onSelectTab: (tab: string) => void;
+}) => {
+  const selectedTab = selectedTabProp ?? tabs[0].id;
+  return (
+    <div className='flex w-fit space-x-1 rounded-full border border-[#E4E4E7] p-1'>
+      {tabs.map((tab) => (
+        <Tooltip key={tab.id}>
+          <TooltipTrigger asChild>
+            <button
+              key={tab.id}
+              aria-label={tab.tooltip}
+              onClick={() => onSelectTab(tab.id)}
+              className={cn(
+                'relative rounded-full p-1 text-sm font-medium text-[#E4E4E7] transition focus-visible:outline-2',
+                selectedTab !== tab.id && 'hover:text-black/60',
+                selectedTab === tab.id && 'text-black shadow-lg'
+              )}
+              style={{
+                WebkitTapHighlightColor: 'transparent',
+              }}
+            >
+              {selectedTab === tab.id && (
+                <motion.span
+                  layoutId='bubble'
+                  className='absolute inset-0 z-10 bg-white mix-blend-difference'
+                  style={{ borderRadius: 9999 }}
+                  transition={{ type: 'spring', bounce: 0.2, duration: 0.3 }}
+                />
+              )}
+              {tab.icon}
+            </button>
+          </TooltipTrigger>
+          <TooltipContent
+            className='max-w-40 text-center'
+            side='top'
+            sideOffset={12}
+          >
+            <p>{tab.tooltip}</p>
+          </TooltipContent>
+        </Tooltip>
+      ))}
+    </div>
+  );
+};

--- a/src/app/[handle]/components/mobile-switch/animated-tabs.tsx
+++ b/src/app/[handle]/components/mobile-switch/animated-tabs.tsx
@@ -49,6 +49,7 @@ export const AnimatedTabs = ({
               {selectedTab === tab.id && (
                 <motion.span
                   layoutId='bubble'
+                  layoutDependency={selectedTab}
                   className='absolute inset-0 z-10 bg-white mix-blend-difference'
                   style={{ borderRadius: 9999 }}
                   transition={{ type: 'spring', bounce: 0.2, duration: 0.3 }}

--- a/src/app/[handle]/components/mobile-switch/mobile-switch.stories.tsx
+++ b/src/app/[handle]/components/mobile-switch/mobile-switch.stories.tsx
@@ -1,4 +1,6 @@
+import { useArgs } from '@storybook/preview-api';
 import { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 import { MobileSwitch } from './mobile-switch';
 
@@ -14,4 +16,30 @@ export default meta;
 
 type Story = StoryObj<typeof MobileSwitch>;
 
-export const Default: Story = {};
+export const Default: Story = {
+  args: {
+    isMobile: false,
+    onIsMobileChange: fn(),
+  },
+};
+
+export const Mobile: Story = {
+  args: {
+    isMobile: true,
+    onIsMobileChange: fn(),
+  },
+};
+
+export const Interactive: Story = {
+  args: Default.args,
+  render: (args) => {
+    const [{ isMobile }, setArgs] = useArgs();
+    return (
+      <MobileSwitch
+        {...args}
+        isMobile={isMobile}
+        onIsMobileChange={(isMobile) => setArgs({ isMobile })}
+      />
+    );
+  },
+};

--- a/src/app/[handle]/components/mobile-switch/mobile-switch.stories.tsx
+++ b/src/app/[handle]/components/mobile-switch/mobile-switch.stories.tsx
@@ -1,0 +1,17 @@
+import { Meta, StoryObj } from '@storybook/react';
+
+import { MobileSwitch } from './mobile-switch';
+
+const meta = {
+  title: 'Mobile Switch',
+  component: MobileSwitch,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof MobileSwitch>;
+
+export default meta;
+
+type Story = StoryObj<typeof MobileSwitch>;
+
+export const Default: Story = {};

--- a/src/app/[handle]/components/mobile-switch/mobile-switch.tsx
+++ b/src/app/[handle]/components/mobile-switch/mobile-switch.tsx
@@ -1,4 +1,5 @@
 import { AnimatedTabs } from './animated-tabs';
+import { NewFeatureBadge } from './new-feature-badge';
 
 export const MobileSwitch = ({
   isMobile,
@@ -12,11 +13,15 @@ export const MobileSwitch = ({
     onIsMobileChange(tab === 'mobile');
   };
   return (
-    <AnimatedTabs
-      tabs={tabs}
-      selectedTab={selectedTab}
-      onSelectTab={onSelectTab}
-    />
+    // TODO: Remove this relative div once the new feature badge is removed
+    <div className='relative'>
+      <AnimatedTabs
+        tabs={tabs}
+        selectedTab={selectedTab}
+        onSelectTab={onSelectTab}
+      />
+      <NewFeatureBadge />
+    </div>
   );
 };
 

--- a/src/app/[handle]/components/mobile-switch/mobile-switch.tsx
+++ b/src/app/[handle]/components/mobile-switch/mobile-switch.tsx
@@ -1,0 +1,77 @@
+import { useState } from 'react';
+
+import { AnimatedTabs } from './animated-tabs';
+
+export const MobileSwitch = () => {
+  const [selectedTab, setSelectedTab] = useState(tabs[0].id);
+  return (
+    <AnimatedTabs
+      tabs={tabs}
+      selectedTab={selectedTab}
+      onSelectTab={setSelectedTab}
+    />
+  );
+};
+
+const MobileIcon = () => {
+  return (
+    <svg
+      width='16'
+      height='16'
+      viewBox='0 0 16 16'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <rect
+        x='5.5'
+        y='3.5'
+        width='5'
+        height='9'
+        rx='0.5'
+        stroke='currentColor'
+      />
+    </svg>
+  );
+};
+
+const DesktopIcon = () => {
+  return (
+    <svg
+      width='16'
+      height='16'
+      viewBox='0 0 16 16'
+      fill='none'
+      xmlns='http://www.w3.org/2000/svg'
+    >
+      <rect
+        x='2.43335'
+        y='4.5'
+        width='11.1333'
+        height='7'
+        rx='0.5'
+        stroke='currentColor'
+      />
+      <rect
+        x='1.5'
+        y='11.5'
+        width='13'
+        height='2'
+        rx='0.5'
+        stroke='currentColor'
+      />
+    </svg>
+  );
+};
+
+const tabs = [
+  {
+    id: 'desktop',
+    icon: <DesktopIcon />,
+    tooltip: 'How your profile looks on computers',
+  },
+  {
+    id: 'mobile',
+    icon: <MobileIcon />,
+    tooltip: 'How your profile looks on phones',
+  },
+];

--- a/src/app/[handle]/components/mobile-switch/mobile-switch.tsx
+++ b/src/app/[handle]/components/mobile-switch/mobile-switch.tsx
@@ -1,14 +1,21 @@
-import { useState } from 'react';
-
 import { AnimatedTabs } from './animated-tabs';
 
-export const MobileSwitch = () => {
-  const [selectedTab, setSelectedTab] = useState(tabs[0].id);
+export const MobileSwitch = ({
+  isMobile,
+  onIsMobileChange,
+}: {
+  isMobile: boolean;
+  onIsMobileChange: (isMobile: boolean) => void;
+}) => {
+  const selectedTab = isMobile ? 'mobile' : 'desktop';
+  const onSelectTab = (tab: string) => {
+    onIsMobileChange(tab === 'mobile');
+  };
   return (
     <AnimatedTabs
       tabs={tabs}
       selectedTab={selectedTab}
-      onSelectTab={setSelectedTab}
+      onSelectTab={onSelectTab}
     />
   );
 };

--- a/src/app/[handle]/components/mobile-switch/new-feature-badge.tsx
+++ b/src/app/[handle]/components/mobile-switch/new-feature-badge.tsx
@@ -1,0 +1,8 @@
+export const NewFeatureBadge = () => {
+  return (
+    <div
+      title='New'
+      className='bg-sorbet group absolute right-0 top-0 -translate-y-[1px] translate-x-1/4 rounded-full p-1.5'
+    ></div>
+  );
+};

--- a/src/app/[handle]/components/mobile-switch/new-feature-badge.tsx
+++ b/src/app/[handle]/components/mobile-switch/new-feature-badge.tsx
@@ -2,7 +2,7 @@ export const NewFeatureBadge = () => {
   return (
     <div
       title='New'
-      className='bg-sorbet group absolute right-0 top-0 -translate-y-[1px] translate-x-1/4 rounded-full p-1.5'
+      className='bg-sorbet group absolute right-0 top-0 size-3 -translate-y-[1px] translate-x-1/4 rounded-full'
     ></div>
   );
 };

--- a/src/app/[handle]/components/profile.tsx
+++ b/src/app/[handle]/components/profile.tsx
@@ -157,7 +157,7 @@ export const Profile = ({
                     onAddImage={handleAddImage}
                     onAddLink={handleAddLink}
                     onShare={() => setIsShareDialogOpen(true)}
-                    isMobile={isMobile}
+                    isDisabled={isMobile}
                   />
                 </motion.div>
               </div>

--- a/src/app/[handle]/components/profile.tsx
+++ b/src/app/[handle]/components/profile.tsx
@@ -146,32 +146,6 @@ export const Profile = ({
       </ArtificialMobile>
 
       {/* Elements which ignore the layout of this container */}
-      {!showOnboarding && (
-        <div className='fix-modal-layout-shift fixed bottom-0 left-1/2 -translate-x-1/2 -translate-y-6 transform'>
-          <motion.div
-            initial={{ y: 100, opacity: 0 }}
-            animate={!isLoading ? { opacity: 1, y: 0 } : { opacity: 0, y: 100 }}
-            transition={{
-              delay: 1,
-              type: 'spring',
-              stiffness: 150,
-              damping: 30,
-              mass: 2,
-            }}
-          >
-            <ControlBar
-              onAddImage={handleAddImage}
-              onAddLink={handleAddLink}
-              onShare={() => setIsShareDialogOpen(true)}
-              isDisabled={isMobileDevice}
-              isMobile={isArtificialMobile}
-              onIsMobileChange={
-                isMobileScreen ? undefined : setIsArtificialMobile
-              }
-            />
-          </motion.div>
-        </div>
-      )}
       <ContactMeDialog
         open={isContactMeDialogOpen}
         onOpenChange={setIsContactMeDialogOpen}
@@ -188,6 +162,34 @@ export const Profile = ({
             setOpen={setIsEditing}
             user={user}
           />
+          {!showOnboarding && (
+            <div className='fix-modal-layout-shift fixed bottom-0 left-1/2 -translate-x-1/2 -translate-y-6 transform'>
+              <motion.div
+                initial={{ y: 100, opacity: 0 }}
+                animate={
+                  !isLoading ? { opacity: 1, y: 0 } : { opacity: 0, y: 100 }
+                }
+                transition={{
+                  delay: 1,
+                  type: 'spring',
+                  stiffness: 150,
+                  damping: 30,
+                  mass: 2,
+                }}
+              >
+                <ControlBar
+                  onAddImage={handleAddImage}
+                  onAddLink={handleAddLink}
+                  onShare={() => setIsShareDialogOpen(true)}
+                  isDisabled={isMobileDevice}
+                  isMobile={isArtificialMobile}
+                  onIsMobileChange={
+                    isMobileScreen ? undefined : setIsArtificialMobile
+                  }
+                />
+              </motion.div>
+            </div>
+          )}
         </>
       )}
     </>

--- a/src/app/[handle]/components/profile.tsx
+++ b/src/app/[handle]/components/profile.tsx
@@ -6,6 +6,7 @@ import { useQueryState } from 'nuqs';
 import { useState } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
 
+import { ArtificialMobile } from '@/app/[handle]/components/artificial-mobile';
 import { useIsMobile } from '@/hooks/use-mobile';
 import { cn } from '@/lib/utils';
 import { MinimalUser } from '@/types';
@@ -64,115 +65,80 @@ export const Profile = ({
   // Shrink the parent container to simulate a mobile view
   const [isArtificialMobile, setIsArtificialMobile] = useState(false);
 
+  // [81rem] is the breakpoint at which we switch from a a mobile layout to a desktop layout
+  // We arrive at this number by finding the maximum width that can show both the left info section and the right widget grid
+
   return (
-    <div
-      className={cn(
-        'size-full transition-all duration-300',
-        isArtificialMobile && 'bg-muted/70 py-4 pb-28'
-      )}
-    >
-      {/* This is the container which forces a mobile view or not */}
-      <motion.div
-        className={cn(
-          '@container bg-background relative mx-auto size-full',
-          isArtificialMobile &&
-            'border-muted w-[448px] overflow-clip rounded-3xl border-2 shadow-md'
-        )}
-        initial={{ width: '100%' }}
-        animate={{
-          width: isArtificialMobile ? '448px' : '100%',
-        }}
-        transition={{ duration: 0.3, ease: 'easeOut' }}
+    <>
+      <ArtificialMobile
+        isMobile={isArtificialMobile}
+        className={cn(isArtificialMobile && 'pb-24')}
       >
-        {/* Main row or col of the profile. */}
-        <motion.div
-          className='@[81rem]:flex-row @[81rem]:overflow-y-visible flex size-full flex-col items-center overflow-y-auto'
-          initial={{ opacity: 0 }}
-          animate={{
-            opacity: isArtificialMobile ? [1, 0, 0, 1] : 1, // Apply the opacity trick
-          }}
-          transition={{
-            duration: 1, // Total duration
-            times: [0, 0, 0.7, 1], // Quick fade-in, hold, and fade-out
-          }}
-        >
-          {/* Left part of the profile. desktop: full height and long enough to render profile details in desktop mode. */}
-          {/* mobile: auto height and short enough to render profile details in mobile mode. */}
-          <div
-            className={cn(
-              '@[81rem]:h-full @[81rem]:min-w-96 flex w-[328px] flex-col justify-between gap-6 p-6',
-              'animate-in fade-in-0 duration-500'
-            )}
-          >
-            <ProfileDetails
-              user={user}
-              isMine={isMine}
-              onEdit={() => setIsEditing(true)}
-              onContactMe={() => setIsContactMeDialogOpen(true)}
-            />
-            <ExitLinks
-              isLoggedIn={isLoggedIn}
-              isMine={isMine}
-              className='@[81rem]:flex hidden'
-            />
-          </div>
-          {/* The right side of the profile. Should handle scroll itself (except on mobile, where the whole page will scroll*/}
-          <div className='@[81rem]:max-w-none @[81rem]:h-full @[81rem]:overflow-y-auto @[81rem]:flex-1 w-full max-w-[895px]'>
-            {showOnboarding ? (
-              <div className='flex h-full w-full items-center justify-center'>
-                <OnboardWithHandles onSubmit={handleAddMultipleWidgets} />
-              </div>
-            ) : (
-              <>
-                <motion.div
-                  initial={{ opacity: 0, y: 10 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  transition={{ duration: 1, delay: 0.5, ease: 'easeOut' }}
-                  className={cn(!isArtificialMobile && '@[81rem]:mb-20')} // Little hack to make sure control bar doesn't overlap the bottommost widget controls
-                >
-                  <ErrorBoundary FallbackComponent={GridErrorFallback}>
-                    <WidgetGrid immutable={!isMine || disableControlBar} />
-                  </ErrorBoundary>
-                </motion.div>
-                {/* Little motion hack to prevent a flash of the exit links when the page loads */}
-                <motion.div
-                  initial={{ opacity: 0 }}
-                  animate={!isLoading ? { opacity: 1 } : { opacity: 0 }}
-                  transition={{ duration: 1, delay: 0.5 }}
-                >
-                  <ExitLinks
-                    isLoggedIn={isLoggedIn}
-                    isMine={isMine}
-                    className={cn(
-                      '@[81rem]:hidden w-full items-center justify-center p-6',
-                      isMine && !isArtificialMobile && 'mb-20'
-                    )}
-                  />
-                </motion.div>
-              </>
-            )}
-          </div>
-          {/* Elements which ignore the layout of this container */}
-          <ContactMeDialog
-            open={isContactMeDialogOpen}
-            onOpenChange={setIsContactMeDialogOpen}
-            userId={user.id}
-          />
-          {isMine && (
-            <>
-              <ShareDialog
-                open={isShareDialogOpen}
-                setOpen={setIsShareDialogOpen}
-              />
-              <EditProfileSheet
-                open={isEditing}
-                setOpen={setIsEditing}
+        <div className='@container size-full'>
+          {/* Main row or col of the profile. */}
+          <div className='@[81rem]:flex-row @[81rem]:overflow-y-visible flex size-full flex-col items-center overflow-y-auto'>
+            {/* Left info section. desktop: full height and long enough width to render its child in desktop mode. */}
+            {/* mobile: auto height and short enough to render profile details in mobile mode. */}
+            <div
+              className={cn(
+                '@[81rem]:h-full @[81rem]:min-w-96 flex w-[328px] flex-col justify-between gap-6 p-6',
+                'animate-in fade-in-0 duration-500'
+              )}
+            >
+              <ProfileDetails
                 user={user}
+                isMine={isMine}
+                onEdit={() => setIsEditing(true)}
+                onContactMe={() => setIsContactMeDialogOpen(true)}
               />
-            </>
-          )}
-        </motion.div>
-      </motion.div>
+              <ExitLinks
+                isLoggedIn={isLoggedIn}
+                isMine={isMine}
+                className='@[81rem]:flex hidden'
+              />
+            </div>
+            {/* The right side of the profile. Desktop: Handles scroll itself. Mobile: Scrolls the parent container */}
+            <div className='@[81rem]:max-w-none @[81rem]:h-full @[81rem]:overflow-y-auto @[81rem]:flex-1 w-full max-w-[895px]'>
+              {showOnboarding ? (
+                <div className='flex h-full w-full items-center justify-center'>
+                  <OnboardWithHandles onSubmit={handleAddMultipleWidgets} />
+                </div>
+              ) : (
+                <>
+                  <motion.div
+                    initial={{ opacity: 0, y: 10 }}
+                    animate={{ opacity: 1, y: 0 }}
+                    transition={{ duration: 1, delay: 0.5, ease: 'easeOut' }}
+                    // Little hack to make sure control bar doesn't overlap the bottommost widget controls
+                    className={cn(!isArtificialMobile && '@[81rem]:mb-20')}
+                  >
+                    <ErrorBoundary FallbackComponent={GridErrorFallback}>
+                      <WidgetGrid immutable={!isMine || disableControlBar} />
+                    </ErrorBoundary>
+                  </motion.div>
+                  {/* Little motion hack to prevent a flash of the exit links when the page loads */}
+                  <motion.div
+                    initial={{ opacity: 0 }}
+                    animate={!isLoading ? { opacity: 1 } : { opacity: 0 }}
+                    transition={{ duration: 1, delay: 0.5 }}
+                  >
+                    <ExitLinks
+                      isLoggedIn={isLoggedIn}
+                      isMine={isMine}
+                      className={cn(
+                        '@[81rem]:hidden w-full items-center justify-center p-6',
+                        isMine && !isArtificialMobile && 'mb-20'
+                      )}
+                    />
+                  </motion.div>
+                </>
+              )}
+            </div>
+          </div>
+        </div>
+      </ArtificialMobile>
+
+      {/* Elements which ignore the layout of this container */}
       {!showOnboarding && (
         <div className='fix-modal-layout-shift fixed bottom-0 left-1/2 -translate-x-1/2 -translate-y-6 transform'>
           <motion.div
@@ -199,6 +165,24 @@ export const Profile = ({
           </motion.div>
         </div>
       )}
-    </div>
+      <ContactMeDialog
+        open={isContactMeDialogOpen}
+        onOpenChange={setIsContactMeDialogOpen}
+        userId={user.id}
+      />
+      {isMine && (
+        <>
+          <ShareDialog
+            open={isShareDialogOpen}
+            setOpen={setIsShareDialogOpen}
+          />
+          <EditProfileSheet
+            open={isEditing}
+            setOpen={setIsEditing}
+            user={user}
+          />
+        </>
+      )}
+    </>
   );
 };

--- a/src/app/[handle]/components/profile.tsx
+++ b/src/app/[handle]/components/profile.tsx
@@ -117,7 +117,7 @@ export const Profile = ({
                     animate={{ opacity: 1, y: 0 }}
                     transition={{ duration: 1, delay: 0.5, ease: 'easeOut' }}
                     // Little hack to make sure control bar doesn't overlap the bottommost widget controls
-                    className={cn(!isArtificialMobile && '@[81rem]:mb-20')}
+                    className={cn(!showArtificialMobile && '@[81rem]:mb-20')}
                   >
                     <ErrorBoundary FallbackComponent={GridErrorFallback}>
                       <WidgetGrid immutable={!isMine || isMobileDevice} />
@@ -134,7 +134,7 @@ export const Profile = ({
                       isMine={isMine}
                       className={cn(
                         '@[81rem]:hidden w-full items-center justify-center p-6',
-                        isMine && !isArtificialMobile && 'mb-20'
+                        isMine && !showArtificialMobile && 'mb-20'
                       )}
                     />
                   </motion.div>

--- a/src/app/[handle]/components/profile.tsx
+++ b/src/app/[handle]/components/profile.tsx
@@ -58,113 +58,147 @@ export const Profile = ({
 
   useHandlePaste(addWidget, isMine && !isLoading);
 
-  // This hook fires at 768px, aligning perfectly with our @3xl breakpoint below
-  const isMobile = useIsMobile();
+  // This hook fires at 768px, which we will consider the user to be on a mobile device
+  const disableControlBar = useIsMobile();
+
+  // Shrink the parent container to simulate a mobile view
+  const [isArtificialMobile, setIsArtificialMobile] = useState(false);
 
   return (
-    <div className='@container size-full'>
-      <div className='@3xl:flex-row @3xl:overflow-y-visible flex size-full flex-col items-center overflow-y-auto'>
-        {/* Left part of the profile. desktop: full height and long enough to render profile details in desktop mode. */}
-        {/* mobile: auto height and short enough to render profile details in mobile mode. */}
-        <div
-          className={cn(
-            '@3xl:h-full @3xl:min-w-96 flex w-[328px] flex-col justify-between gap-6 p-6',
-            'animate-in fade-in-0 duration-500'
-          )}
+    <div
+      className={cn(
+        'size-full transition-all duration-300',
+        isArtificialMobile && 'bg-muted/70 py-4 pb-28'
+      )}
+    >
+      {/* This is the container which forces a mobile view or not */}
+      <motion.div
+        className={cn(
+          '@container bg-background relative mx-auto size-full',
+          isArtificialMobile &&
+            'border-muted w-[448px] overflow-clip rounded-3xl border-2 shadow-md'
+        )}
+        initial={{ width: '100%' }}
+        animate={{
+          width: isArtificialMobile ? '448px' : '100%',
+        }}
+        transition={{ duration: 0.3, ease: 'easeOut' }}
+      >
+        {/* Main row or col of the profile. */}
+        <motion.div
+          className='@[81rem]:flex-row @[81rem]:overflow-y-visible flex size-full flex-col items-center overflow-y-auto'
+          initial={{ opacity: 0 }}
+          animate={{
+            opacity: isArtificialMobile ? [1, 0, 0, 1] : 1, // Apply the opacity trick
+          }}
+          transition={{
+            duration: 1, // Total duration
+            times: [0, 0, 0.7, 1], // Quick fade-in, hold, and fade-out
+          }}
         >
-          <ProfileDetails
-            user={user}
-            isMine={isMine}
-            onEdit={() => setIsEditing(true)}
-            onContactMe={() => setIsContactMeDialogOpen(true)}
-          />
-          <ExitLinks
-            isLoggedIn={isLoggedIn}
-            isMine={isMine}
-            className='@3xl:flex hidden'
-          />
-        </div>
-        {/* The right side of the profile. Should handle scroll itself (except on mobile, where the whole page will scroll*/}
-        <div className='@3xl:w-auto @3xl:h-full @3xl:overflow-y-auto @3xl:flex-1 w-full'>
-          {showOnboarding ? (
-            <div className='flex h-full w-full items-center justify-center'>
-              <OnboardWithHandles onSubmit={handleAddMultipleWidgets} />
-            </div>
-          ) : (
-            <>
-              <motion.div
-                initial={{ opacity: 0, y: 10 }}
-                animate={{ opacity: 1, y: 0 }}
-                transition={{ duration: 1, delay: 0.5, ease: 'easeOut' }}
-                className='@3xl:mb-20' // Little hack to make sure control bar doesn't overlap the bottommost widget controls
-              >
-                <ErrorBoundary FallbackComponent={GridErrorFallback}>
-                  <WidgetGrid immutable={!isMine || isMobile} />
-                </ErrorBoundary>
-              </motion.div>
-              {/* Little motion hack to prevent a flash of the exit links when the page loads */}
-              <motion.div
-                initial={{ opacity: 0 }}
-                animate={!isLoading ? { opacity: 1 } : { opacity: 0 }}
-                transition={{ duration: 1, delay: 0.5 }}
-              >
-                <ExitLinks
-                  isLoggedIn={isLoggedIn}
-                  isMine={isMine}
-                  className={cn(
-                    '@3xl:hidden w-full items-center justify-center p-6',
-                    isMine && 'mb-20'
-                  )}
-                />
-              </motion.div>
-            </>
-          )}
-        </div>
-
-        {/* Elements which ignore the layout of this container */}
-        <ContactMeDialog
-          open={isContactMeDialogOpen}
-          onOpenChange={setIsContactMeDialogOpen}
-          userId={user.id}
-        />
-        {isMine && (
-          <>
-            <ShareDialog
-              open={isShareDialogOpen}
-              setOpen={setIsShareDialogOpen}
-            />
-            <EditProfileSheet
-              open={isEditing}
-              setOpen={setIsEditing}
+          {/* Left part of the profile. desktop: full height and long enough to render profile details in desktop mode. */}
+          {/* mobile: auto height and short enough to render profile details in mobile mode. */}
+          <div
+            className={cn(
+              '@[81rem]:h-full @[81rem]:min-w-96 flex w-[328px] flex-col justify-between gap-6 p-6',
+              'animate-in fade-in-0 duration-500'
+            )}
+          >
+            <ProfileDetails
               user={user}
+              isMine={isMine}
+              onEdit={() => setIsEditing(true)}
+              onContactMe={() => setIsContactMeDialogOpen(true)}
             />
-            {!showOnboarding && (
-              <div className='fix-modal-layout-shift fixed bottom-0 left-1/2 -translate-x-1/2 -translate-y-6 transform'>
+            <ExitLinks
+              isLoggedIn={isLoggedIn}
+              isMine={isMine}
+              className='@[81rem]:flex hidden'
+            />
+          </div>
+          {/* The right side of the profile. Should handle scroll itself (except on mobile, where the whole page will scroll*/}
+          <div className='@[81rem]:max-w-none @[81rem]:h-full @[81rem]:overflow-y-auto @[81rem]:flex-1 w-full max-w-[895px]'>
+            {showOnboarding ? (
+              <div className='flex h-full w-full items-center justify-center'>
+                <OnboardWithHandles onSubmit={handleAddMultipleWidgets} />
+              </div>
+            ) : (
+              <>
                 <motion.div
-                  initial={{ y: 100, opacity: 0 }}
-                  animate={
-                    !isLoading ? { opacity: 1, y: 0 } : { opacity: 0, y: 100 }
-                  }
-                  transition={{
-                    delay: 1,
-                    type: 'spring',
-                    stiffness: 150,
-                    damping: 30,
-                    mass: 2,
-                  }}
+                  initial={{ opacity: 0, y: 10 }}
+                  animate={{ opacity: 1, y: 0 }}
+                  transition={{ duration: 1, delay: 0.5, ease: 'easeOut' }}
+                  className={cn(!isArtificialMobile && '@[81rem]:mb-20')} // Little hack to make sure control bar doesn't overlap the bottommost widget controls
                 >
-                  <ControlBar
-                    onAddImage={handleAddImage}
-                    onAddLink={handleAddLink}
-                    onShare={() => setIsShareDialogOpen(true)}
-                    isDisabled={isMobile}
+                  <ErrorBoundary FallbackComponent={GridErrorFallback}>
+                    <WidgetGrid immutable={!isMine || disableControlBar} />
+                  </ErrorBoundary>
+                </motion.div>
+                {/* Little motion hack to prevent a flash of the exit links when the page loads */}
+                <motion.div
+                  initial={{ opacity: 0 }}
+                  animate={!isLoading ? { opacity: 1 } : { opacity: 0 }}
+                  transition={{ duration: 1, delay: 0.5 }}
+                >
+                  <ExitLinks
+                    isLoggedIn={isLoggedIn}
+                    isMine={isMine}
+                    className={cn(
+                      '@[81rem]:hidden w-full items-center justify-center p-6',
+                      isMine && !isArtificialMobile && 'mb-20'
+                    )}
                   />
                 </motion.div>
-              </div>
+              </>
             )}
-          </>
-        )}
-      </div>
+          </div>
+          {/* Elements which ignore the layout of this container */}
+          <ContactMeDialog
+            open={isContactMeDialogOpen}
+            onOpenChange={setIsContactMeDialogOpen}
+            userId={user.id}
+          />
+          {isMine && (
+            <>
+              <ShareDialog
+                open={isShareDialogOpen}
+                setOpen={setIsShareDialogOpen}
+              />
+              <EditProfileSheet
+                open={isEditing}
+                setOpen={setIsEditing}
+                user={user}
+              />
+            </>
+          )}
+        </motion.div>
+      </motion.div>
+      {!showOnboarding && (
+        <div className='fix-modal-layout-shift fixed bottom-0 left-1/2 -translate-x-1/2 -translate-y-6 transform'>
+          <motion.div
+            initial={{ y: 100, opacity: 0 }}
+            animate={!isLoading ? { opacity: 1, y: 0 } : { opacity: 0, y: 100 }}
+            transition={{
+              delay: 1,
+              type: 'spring',
+              stiffness: 150,
+              damping: 30,
+              mass: 2,
+            }}
+          >
+            <ControlBar
+              onAddImage={handleAddImage}
+              onAddLink={handleAddLink}
+              onShare={() => setIsShareDialogOpen(true)}
+              isDisabled={disableControlBar}
+              isMobile={isArtificialMobile}
+              onIsMobileChange={
+                disableControlBar ? undefined : setIsArtificialMobile
+              }
+            />
+          </motion.div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/hooks/use-container-query.stories.tsx
+++ b/src/hooks/use-container-query.stories.tsx
@@ -1,0 +1,58 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+import { Button } from '@/components/ui/button';
+
+import { useContainerQuery } from './use-container-query';
+
+const ContainerQueryDemo = () => {
+  const { ref, matches: isLargeEnough } =
+    useContainerQuery<HTMLDivElement>('20rem');
+
+  return (
+    <div className='flex flex-col gap-4'>
+      <div className='text-sm'>
+        Resize the container below to see the hook in action.
+        <br />
+        Current state:{' '}
+        {isLargeEnough
+          ? 'Container is at least 20rem wide'
+          : 'Container is less than 20rem wide'}
+      </div>
+
+      <div
+        ref={ref}
+        className='max-w-full resize-x overflow-auto border border-dashed p-4'
+        style={{ width: '300px', minWidth: '100px' }}
+      >
+        <div className='flex gap-2'>
+          <Button
+            variant={isLargeEnough ? 'default' : 'outline'}
+            onClick={fn()}
+          >
+            Action 1
+          </Button>
+          {isLargeEnough && (
+            <Button variant='outline' onClick={fn()}>
+              Action 2
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+type Story = StoryObj<typeof ContainerQueryDemo>;
+
+const meta = {
+  title: 'Hooks/useContainerQuery',
+  component: ContainerQueryDemo,
+  parameters: {
+    layout: 'centered',
+  },
+} satisfies Meta<typeof ContainerQueryDemo>;
+
+export default meta;
+
+export const Default: Story = {};

--- a/src/hooks/use-container-query.tsx
+++ b/src/hooks/use-container-query.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from 'react';
+
+/**
+ * Hook that checks if a container's width is at least the specified width
+ *
+ * Note: Fast vibe coded solution. Revisit and vet if this becomes more widely needed.
+ *
+ * @param ref Reference to the container element to observe
+ * @param minWidth Minimum width to check for (e.g. '81rem')
+ */
+export function useContainerQuery<T extends HTMLElement>(
+  minWidth: string
+): { ref: React.RefObject<T>; matches: boolean } {
+  const ref = useRef<T>(null);
+  const [matches, setMatches] = useState(false);
+
+  useEffect(() => {
+    if (!ref.current || typeof window === 'undefined') return;
+
+    // Convert rem to pixels for calculation
+    const remValue = parseFloat(minWidth.replace('rem', ''));
+    const pixelValue =
+      remValue *
+      parseFloat(getComputedStyle(document.documentElement).fontSize);
+
+    const observer = new ResizeObserver((entries) => {
+      for (const entry of entries) {
+        const width = entry.contentRect.width;
+        setMatches(width >= pixelValue);
+      }
+    });
+
+    observer.observe(ref.current);
+
+    return () => {
+      observer.disconnect();
+    };
+  }, [ref, minWidth]);
+
+  return { ref, matches };
+}


### PR DESCRIPTION
**Main Changes**

- Add `animated-tabs` component based on build-ui and tweaked for our use case
- Add `mobile-switch` which specialized the above with icons and state
- Add mobile switch to control bar and pass props up
- Render a temporary 'new' badge on the mobile switch
- Add a `artificial-mobile` component to wrap the profile and constrain it to an artificial mobile viewport when told to do so by the `mobile-switch`
- Bring all of the above together with state in `profile`
- Profile breaks to mobile layout at 81rem to get rid of confusing half mobile half desktop layout
- Share profile -> share and make the button shine

**Additional Changes**
- Add a storybook code snippet for faster story creation
- Add a `use-container-query` hook to bring container queries into state
- Update the grid to use a controlled breakpoint instead of relying on an ancient width observer to trigger the onBreakpointChange callback