### PR TITLE
Organize and Refactor Grid

### DIFF
--- a/src/api/widgets-v2/mock-widgets.ts
+++ b/src/api/widgets-v2/mock-widgets.ts
@@ -1,10 +1,21 @@
-import { WidgetData } from '@/app/[handle]/components/widget/grid-config';
+import { WidgetData } from '@/api/widgets-v2/types';
 
 import { sampleLayoutLg, sampleLayoutSm } from './sample-layout';
 import { ApiWidget } from './types';
 
+const nulls: Omit<WidgetData, 'id'> = {
+  title: null,
+  userTitle: null,
+  iconUrl: null,
+  type: null,
+  custom: null,
+  contentUrl: null,
+  href: null,
+};
+
 export const mockWidgetData: Record<string, WidgetData> = {
   a: {
+    ...nulls,
     id: 'a',
     title: 'Widget 1',
     contentUrl: 'https://picsum.photos/400/300?grayscale',
@@ -13,13 +24,18 @@ export const mockWidgetData: Record<string, WidgetData> = {
     userTitle: 'User Title 1',
   },
   b: {
+    ...nulls,
     id: 'b',
     title: 'Widget 2',
     contentUrl: 'https://picsum.photos/300/400?grayscale',
     href: 'https://picsum.photos/300/400?grayscale',
     iconUrl: 'https://picsum.photos/32/32?grayscale',
+    userTitle: null,
+    type: null,
+    custom: null,
   },
   c: {
+    ...nulls,
     id: 'c',
     title: 'Widget 3',
     contentUrl: 'https://picsum.photos/350/350?grayscale',
@@ -27,12 +43,14 @@ export const mockWidgetData: Record<string, WidgetData> = {
     iconUrl: 'https://picsum.photos/32/32?grayscale',
   },
   d: {
+    ...nulls,
     id: 'd',
     contentUrl: 'https://picsum.photos/450/300?grayscale',
     href: 'https://picsum.photos/450/300?grayscale',
     type: 'image',
   },
   e: {
+    ...nulls,
     id: 'e',
     title: 'Widget 5',
     contentUrl: 'https://picsum.photos/500/250?grayscale',
@@ -40,11 +58,13 @@ export const mockWidgetData: Record<string, WidgetData> = {
     iconUrl: 'https://picsum.photos/32/32?grayscale',
   },
   f: {
+    ...nulls,
     id: 'f',
     contentUrl: 'https://picsum.photos/400/400?grayscale',
     type: 'image',
   },
   g: {
+    ...nulls,
     id: 'g',
     title: 'Widget 7',
     contentUrl: 'https://picsum.photos/600/600?grayscale',
@@ -52,10 +72,27 @@ export const mockWidgetData: Record<string, WidgetData> = {
     iconUrl: 'https://picsum.photos/32/32?grayscale',
   },
   h: {
+    ...nulls,
     id: 'h',
     title: 'Widget 8',
     contentUrl: 'https://picsum.photos/550/550?grayscale',
     href: 'https://picsum.photos/550/550?grayscale',
+    iconUrl: 'https://picsum.photos/32/32?grayscale',
+  },
+  i: {
+    ...nulls,
+    id: 'i',
+    title: 'Widget 9',
+    contentUrl: 'https://picsum.photos/600/600?grayscale',
+    href: 'https://picsum.photos/600/600?grayscale',
+    iconUrl: 'https://picsum.photos/32/32?grayscale',
+  },
+  j: {
+    ...nulls,
+    id: 'j',
+    title: 'Widget 10',
+    contentUrl: 'https://picsum.photos/600/600?grayscale',
+    href: 'https://picsum.photos/600/600?grayscale',
     iconUrl: 'https://picsum.photos/32/32?grayscale',
   },
 };
@@ -85,14 +122,7 @@ export const mockWidgets: ApiWidget[] = Object.values(mockWidgetData).map(
     const lgLayout = sampleLayoutLg.find((l) => l.i === widget.id);
 
     return {
-      id: widget.id,
-      href: widget.href ?? null,
-      title: widget.title ?? null,
-      userTitle: widget.userTitle ?? null,
-      iconUrl: widget.iconUrl ?? null,
-      contentUrl: widget.contentUrl ?? null,
-      type: widget.type ?? null,
-      custom: null,
+      ...widget,
       createdAt: new Date(),
       updatedAt: new Date(),
       userId: '1',

--- a/src/api/widgets-v2/msw-handlers.ts
+++ b/src/api/widgets-v2/msw-handlers.ts
@@ -3,7 +3,7 @@ import { delay, http, HttpResponse } from 'msw';
 import { env } from '@/lib/env';
 
 import { mockWidgets, sampleWidget } from './mock-widgets';
-import { type CreateWidgetDto, type UpdateWidgetV2Dto } from './types';
+import { type CreateWidgetDto, UpdateWidgetDto } from './types';
 
 /**
  * Mock the data from the `/v2/widgets` POST endpoint for creating widgets
@@ -68,7 +68,7 @@ export const mockUpdateWidgetHandler = http.put(
     if (!previousWidget) {
       return new HttpResponse(null, { status: 404 });
     }
-    const updateData = (await request.json()) as UpdateWidgetV2Dto;
+    const updateData = (await request.json()) as UpdateWidgetDto;
     await delay();
 
     return HttpResponse.json({

--- a/src/api/widgets-v2/sample-layout.ts
+++ b/src/api/widgets-v2/sample-layout.ts
@@ -1,20 +1,29 @@
 import { Layout } from 'react-grid-layout';
 
-import {
-  Breakpoint,
-  WidgetData,
-} from '@/app/[handle]/components/widget/grid-config';
+import { WidgetData } from '@/api/widgets-v2/types';
+import { Breakpoint } from '@/app/[handle]/components/widget/grid-config';
+
+const nulls: Omit<WidgetData, 'id'> = {
+  contentUrl: null,
+  href: null,
+  iconUrl: null,
+  title: null,
+  userTitle: null,
+  type: null,
+  custom: null,
+};
 
 export const sampleWidgetsMap: Record<string, WidgetData> = {
-  a: { id: 'a', title: 'Widget A' },
-  b: { id: 'b', title: 'Widget B' },
-  c: { id: 'c', title: 'Widget C' },
-  d: { id: 'd', title: 'Widget D' },
-  e: { id: 'e', title: 'Widget E' },
-  f: { id: 'f', title: 'Widget F' },
-  g: { id: 'g', title: 'Widget G' },
-  h: { id: 'h', title: 'Widget H' },
-  // i: { id: 'i', title: 'Widget I' },
+  a: { ...nulls, id: 'a', title: 'Widget A' },
+  b: { ...nulls, id: 'b', title: 'Widget B' },
+  c: { ...nulls, id: 'c', title: 'Widget C' },
+  d: { ...nulls, id: 'd', title: 'Widget D' },
+  e: { ...nulls, id: 'e', title: 'Widget E' },
+  f: { ...nulls, id: 'f', title: 'Widget F' },
+  g: { ...nulls, id: 'g', title: 'Widget G' },
+  h: { ...nulls, id: 'h', title: 'Widget H' },
+  i: { ...nulls, id: 'i', title: 'Widget I' },
+  j: { ...nulls, id: 'j', title: 'Widget J' },
 };
 
 export const sampleLayoutLg: Layout[] = [
@@ -28,7 +37,8 @@ export const sampleLayoutLg: Layout[] = [
 
   { i: 'g', x: 0, y: 4, w: 4, h: 4 }, // Size A
   { i: 'h', x: 4, y: 4, w: 4, h: 4 }, // Size A
-  // { i: 'i', x: 8, y: 4, w: 4, h: 1 }, // Size E
+  { i: 'i', x: 8, y: 4, w: 4, h: 1 }, // Size E
+  { i: 'j', x: 0, y: 4, w: 4, h: 1 }, // Size E
 ];
 
 export const sampleLayoutSm: Layout[] = [
@@ -43,7 +53,8 @@ export const sampleLayoutSm: Layout[] = [
 
   { i: 'g', x: 0, y: 8, w: 4, h: 4 }, // Size A
   { i: 'h', x: 0, y: 12, w: 4, h: 4 }, // Size A
-  // { i: 'i', x: 0, y: 16, w: 4, h: 1 }, // Size E
+  { i: 'i', x: 0, y: 16, w: 4, h: 1 }, // Size E
+  { i: 'j', x: 0, y: 17, w: 4, h: 1 }, // Size E
 ];
 
 export const sampleLayouts: Record<Breakpoint, Layout[]> = {

--- a/src/api/widgets-v2/types.ts
+++ b/src/api/widgets-v2/types.ts
@@ -39,27 +39,6 @@ export type UpdateLayoutsDto = {
 };
 
 /**
- * Shape of the data used to update a widget
- * Should match the UpdateWidgetV2Dto validator in the API
- */
-export type UpdateWidgetV2Dto = {
-  /** The title of the widget. Set by enrichment. */
-  title?: string;
-
-  /** The content URL of the widget */
-  contentUrl?: string;
-
-  /** The URL of the widget. Use null to unset */
-  href?: string | null;
-
-  /** The title a user sets for the widget. Use null to unset */
-  userTitle?: string | null;
-
-  /** Any custom data for the widget */
-  custom?: Record<string, unknown>;
-};
-
-/**
  * Shape of a widget returned from the API
  * Should match the prisma schema
  */
@@ -77,3 +56,22 @@ export type ApiWidget = {
   userId: string;
   layouts: LayoutDto[];
 };
+
+/** This is the subset of information we will actually store about a widget */
+export type WidgetData = Pick<
+  ApiWidget,
+  | 'id'
+  | 'href'
+  | 'title'
+  | 'userTitle'
+  | 'iconUrl'
+  | 'contentUrl'
+  | 'type'
+  | 'custom'
+>;
+
+/**
+ * This is the shape of the data used to update a widget
+ * You can update anything we store besides id
+ */
+export type UpdateWidgetDto = Partial<Omit<WidgetData, 'id'>>;

--- a/src/api/widgets-v2/widgets-v2.ts
+++ b/src/api/widgets-v2/widgets-v2.ts
@@ -7,7 +7,7 @@ import {
   ApiWidget,
   CreateWidgetDto,
   UpdateLayoutsDto,
-  UpdateWidgetV2Dto,
+  UpdateWidgetDto,
 } from './types';
 
 const API_URL = env.NEXT_PUBLIC_SORBET_API_URL;
@@ -72,7 +72,7 @@ export const widgetsV2Api = {
   },
 
   /** Update a widget */
-  update: async (id: string, data: UpdateWidgetV2Dto) => {
+  update: async (id: string, data: UpdateWidgetDto) => {
     const response = await axios.put<ApiWidget>(
       `${API_URL}/v2/widgets/${id}`,
       data,

--- a/src/app/[handle]/components/profile.stories.tsx
+++ b/src/app/[handle]/components/profile.stories.tsx
@@ -15,7 +15,7 @@ const meta = {
   component: Profile,
   parameters: {
     layout: 'fullscreen',
-    // Uncomment to use mock data. As is, this will hit the local api
+    // Comment MSW to hit the local API
     msw: {
       handlers: [
         mockUserByHandleHandler,

--- a/src/app/[handle]/components/widget/grid-config.ts
+++ b/src/app/[handle]/components/widget/grid-config.ts
@@ -50,17 +50,6 @@ export const getWidgetSizeFromDimensions = (
   return size;
 };
 
-// This is the in progress shape of the data representing a widget.
-export type WidgetData = {
-  contentUrl?: string;
-  href?: string | null; // Null explicitly means no value
-  iconUrl?: string;
-  id: string;
-  title?: string;
-  userTitle?: string | null; // Null explicitly means no value
-  type?: 'image';
-};
-
 // 👇 This is size config and calculations for the grid.
 
 export const cols: Record<Breakpoint, number> = {
@@ -68,11 +57,19 @@ export const cols: Record<Breakpoint, number> = {
   sm: 4,
 };
 
+/**
+ * 40px margins for lg breakpoint
+ * 20px for sm breakpoint
+ */
 export const margins: Record<Breakpoint, [number, number]> = {
   lg: [40, 40],
   sm: [20, 20],
 };
 
+/**
+ * This number drives calculations for the rest of the grid.
+ * We say that widgets will be 68px tall, and  everything else is calculated to be square.
+ */
 export const rowHeight = 68;
 
 /**

--- a/src/app/[handle]/components/widget/grid-reducer.tsx
+++ b/src/app/[handle]/components/widget/grid-reducer.tsx
@@ -16,11 +16,8 @@ export type WidgetMap = Record<string, LoadableWidget>;
 export type LayoutMap = Record<Breakpoint, Layout[]>;
 
 // Action payloads
-type AddWidgetStartPayload = { id: string; url: string; type?: WidgetType };
-type AddWidgetCompletePayload = {
-  id: string;
-  data: Omit<LoadableWidget, 'id'>;
-};
+type AddWidgetPayload = { id: string; url: string; type?: WidgetType };
+type UpdateWidgetPayload = { id: string; data: Omit<LoadableWidget, 'id'> };
 type RemoveWidgetPayload = { id: string };
 type UpdateLayoutsPayload = { layouts: LayoutMap };
 type UpdateWidgetSizePayload = { id: string; size: WidgetSize };
@@ -29,8 +26,8 @@ type SetInitialWidgetsPayload = { widgets: WidgetMap; layouts: LayoutMap };
 
 // Actions
 type WidgetAction =
-  | { type: 'ADD_WIDGET_START'; payload: AddWidgetStartPayload }
-  | { type: 'ADD_WIDGET_COMPLETE'; payload: AddWidgetCompletePayload }
+  | { type: 'ADD_WIDGET'; payload: AddWidgetPayload }
+  | { type: 'UPDATE_WIDGET'; payload: UpdateWidgetPayload }
   | { type: 'REMOVE_WIDGET'; payload: RemoveWidgetPayload }
   | { type: 'UPDATE_LAYOUTS'; payload: UpdateLayoutsPayload }
   | { type: 'UPDATE_WIDGET_SIZE'; payload: UpdateWidgetSizePayload }
@@ -57,7 +54,7 @@ function widgetReducer(state: WidgetState, action: WidgetAction): WidgetState {
      * This is so that we can show a loading state in the UI immediately
      * This will update both layout data and widget data
      */
-    case 'ADD_WIDGET_START': {
+    case 'ADD_WIDGET': {
       const { id, url, type } = action.payload;
       return {
         ...state,
@@ -82,8 +79,9 @@ function widgetReducer(state: WidgetState, action: WidgetAction): WidgetState {
     /**
      * Here, we update the widget data with the actual data from the API
      * This will update only the widget data
+     * This will set loading to false
      */
-    case 'ADD_WIDGET_COMPLETE': {
+    case 'UPDATE_WIDGET': {
       const { id, data } = action.payload;
       return {
         ...state,

--- a/src/app/[handle]/components/widget/grid-reducer.tsx
+++ b/src/app/[handle]/components/widget/grid-reducer.tsx
@@ -1,23 +1,21 @@
 import { useReducer } from 'react';
 import { type Layout } from 'react-grid-layout';
 
-import { WidgetType } from '@/api/widgets-v2';
+import { UpdateWidgetDto, WidgetData, WidgetType } from '@/api/widgets-v2';
 
-import {
-  type Breakpoint,
-  type WidgetData,
-  LayoutSizes,
-  WidgetSize,
-} from './grid-config';
+import { type Breakpoint, LayoutSizes, WidgetSize } from './grid-config';
 
-// Types for widget data
+// Types for state
 type LoadableWidget = WidgetData & { loading?: boolean };
 export type WidgetMap = Record<string, LoadableWidget>;
 export type LayoutMap = Record<Breakpoint, Layout[]>;
 
-// Action payloads
+// Payloads
 type AddWidgetPayload = { id: string; url: string; type?: WidgetType };
-type UpdateWidgetPayload = { id: string; data: Omit<LoadableWidget, 'id'> };
+type UpdateWidgetPayload = {
+  id: string;
+  data: UpdateWidgetDto;
+};
 type RemoveWidgetPayload = { id: string };
 type UpdateLayoutsPayload = { layouts: LayoutMap };
 type UpdateWidgetSizePayload = { id: string; size: WidgetSize };
@@ -25,7 +23,7 @@ type SetBreakpointPayload = { breakpoint: Breakpoint };
 type SetInitialWidgetsPayload = { widgets: WidgetMap; layouts: LayoutMap };
 
 // Actions
-type WidgetAction =
+type GridAction =
   | { type: 'ADD_WIDGET'; payload: AddWidgetPayload }
   | { type: 'UPDATE_WIDGET'; payload: UpdateWidgetPayload }
   | { type: 'REMOVE_WIDGET'; payload: RemoveWidgetPayload }
@@ -35,19 +33,24 @@ type WidgetAction =
   | { type: 'SET_INITIAL_WIDGETS'; payload: SetInitialWidgetsPayload };
 
 // State
-type WidgetState = {
+type GridState = {
   widgets: WidgetMap;
   layouts: LayoutMap;
   breakpoint: Breakpoint;
 };
 
+/**
+ * The default layout for a new widget.
+ * All widgets start at 0,0 in a small square size (B).
+ */
 export const DEFAULT_WIDGET_LAYOUT = {
   x: 0,
   y: 0,
   ...LayoutSizes['B'],
 };
 
-function widgetReducer(state: WidgetState, action: WidgetAction): WidgetState {
+/** Use a reducer to manage the state of the grid */
+function gridReducer(state: GridState, action: GridAction): GridState {
   switch (action.type) {
     /**
      * Here, we add the widget to the layout right away in a loading state
@@ -55,16 +58,23 @@ function widgetReducer(state: WidgetState, action: WidgetAction): WidgetState {
      * This will update both layout data and widget data
      */
     case 'ADD_WIDGET': {
-      const { id, url, type } = action.payload;
+      const { id } = action.payload;
+      const type = action.payload.type ?? null; // type is optional so explicitly set to null
+      const href = type === 'image' ? null : action.payload.url; // url is the href for non-image widget creation
+      const contentUrl = type === 'image' ? action.payload.url : null; // if this is an image widget creation, the url is contentUrl
       return {
         ...state,
         widgets: {
           ...state.widgets,
           [id]: {
             id,
-            href: type === 'image' ? undefined : url,
-            contentUrl: type === 'image' ? url : undefined,
+            href,
+            contentUrl,
             type,
+            title: null,
+            userTitle: null,
+            iconUrl: null,
+            custom: null,
             loading: true,
           },
         },
@@ -89,8 +99,8 @@ function widgetReducer(state: WidgetState, action: WidgetAction): WidgetState {
           ...state.widgets,
           [id]: {
             ...state.widgets[id],
-            ...data,
             loading: false,
+            ...data,
           },
         },
       };
@@ -178,8 +188,13 @@ function updateLayoutSize(
   return layouts.map((item) => (item.i === id ? { ...item, ...size } : item));
 }
 
-export const useWidgetReducer = () =>
-  useReducer(widgetReducer, {
+/**
+ * A grid reducer which manages the state of an RGL grid storing widgets and their layouts.
+ *
+ * You can use this for fast optimistic updates, and build a network layer on top of it.
+ */
+export const useGridReducer = () =>
+  useReducer(gridReducer, {
     widgets: {},
     layouts: { sm: [], lg: [] },
     breakpoint: 'lg',

--- a/src/app/[handle]/components/widget/grid-reducer.tsx
+++ b/src/app/[handle]/components/widget/grid-reducer.tsx
@@ -1,0 +1,188 @@
+import { useReducer } from 'react';
+import { type Layout } from 'react-grid-layout';
+
+import { WidgetType } from '@/api/widgets-v2';
+
+import {
+  type Breakpoint,
+  type WidgetData,
+  LayoutSizes,
+  WidgetSize,
+} from './grid-config';
+
+// Types for widget data
+type LoadableWidget = WidgetData & { loading?: boolean };
+export type WidgetMap = Record<string, LoadableWidget>;
+export type LayoutMap = Record<Breakpoint, Layout[]>;
+
+// Action payloads
+type AddWidgetStartPayload = { id: string; url: string; type?: WidgetType };
+type AddWidgetCompletePayload = {
+  id: string;
+  data: Omit<LoadableWidget, 'id'>;
+};
+type RemoveWidgetPayload = { id: string };
+type UpdateLayoutsPayload = { layouts: LayoutMap };
+type UpdateWidgetSizePayload = { id: string; size: WidgetSize };
+type SetBreakpointPayload = { breakpoint: Breakpoint };
+type SetInitialWidgetsPayload = { widgets: WidgetMap; layouts: LayoutMap };
+
+// Actions
+type WidgetAction =
+  | { type: 'ADD_WIDGET_START'; payload: AddWidgetStartPayload }
+  | { type: 'ADD_WIDGET_COMPLETE'; payload: AddWidgetCompletePayload }
+  | { type: 'REMOVE_WIDGET'; payload: RemoveWidgetPayload }
+  | { type: 'UPDATE_LAYOUTS'; payload: UpdateLayoutsPayload }
+  | { type: 'UPDATE_WIDGET_SIZE'; payload: UpdateWidgetSizePayload }
+  | { type: 'SET_BREAKPOINT'; payload: SetBreakpointPayload }
+  | { type: 'SET_INITIAL_WIDGETS'; payload: SetInitialWidgetsPayload };
+
+// State
+type WidgetState = {
+  widgets: WidgetMap;
+  layouts: LayoutMap;
+  breakpoint: Breakpoint;
+};
+
+export const DEFAULT_WIDGET_LAYOUT = {
+  x: 0,
+  y: 0,
+  ...LayoutSizes['B'],
+};
+
+function widgetReducer(state: WidgetState, action: WidgetAction): WidgetState {
+  switch (action.type) {
+    /**
+     * Here, we add the widget to the layout right away in a loading state
+     * This is so that we can show a loading state in the UI immediately
+     * This will update both layout data and widget data
+     */
+    case 'ADD_WIDGET_START': {
+      const { id, url, type } = action.payload;
+      return {
+        ...state,
+        widgets: {
+          ...state.widgets,
+          [id]: {
+            id,
+            href: type === 'image' ? undefined : url,
+            contentUrl: type === 'image' ? url : undefined,
+            type,
+            loading: true,
+          },
+        },
+        // Add widget with default size to both breakpoints
+        layouts: {
+          sm: [{ i: id, ...DEFAULT_WIDGET_LAYOUT }, ...state.layouts.sm],
+          lg: [{ i: id, ...DEFAULT_WIDGET_LAYOUT }, ...state.layouts.lg],
+        },
+      };
+    }
+
+    /**
+     * Here, we update the widget data with the actual data from the API
+     * This will update only the widget data
+     */
+    case 'ADD_WIDGET_COMPLETE': {
+      const { id, data } = action.payload;
+      return {
+        ...state,
+        widgets: {
+          ...state.widgets,
+          [id]: {
+            ...state.widgets[id],
+            ...data,
+            loading: false,
+          },
+        },
+      };
+    }
+
+    /**
+     * Here, we remove the widget from the layout
+     * This will update both layout data and widget data
+     */
+    case 'REMOVE_WIDGET': {
+      const { id } = action.payload;
+      const { [id]: _, ...remainingWidgets } = state.widgets;
+      return {
+        ...state,
+        widgets: remainingWidgets,
+        layouts: {
+          sm: state.layouts.sm.filter((item) => item.i !== id),
+          lg: state.layouts.lg.filter((item) => item.i !== id),
+        },
+      };
+    }
+
+    /**
+     * Here, we just replace all layouts with the new ones (usually reported by rgl)
+     * This will update only the layout data
+     */
+    case 'UPDATE_LAYOUTS': {
+      return {
+        ...state,
+        layouts: action.payload.layouts,
+      };
+    }
+
+    /**
+     * Here, we update the size of a widget
+     * This will update only the layout data
+     */
+    case 'UPDATE_WIDGET_SIZE': {
+      const { id, size } = action.payload;
+      return {
+        ...state,
+        layouts: {
+          ...state.layouts,
+          [state.breakpoint]: updateLayoutSize(
+            state.layouts[state.breakpoint],
+            id,
+            LayoutSizes[size]
+          ),
+        },
+      };
+    }
+
+    /**
+     * Here, we update the current breakpoint
+     * We just need to maintain this state for RGL (and since we base some calculations on it)
+     */
+    case 'SET_BREAKPOINT': {
+      return {
+        ...state,
+        breakpoint: action.payload.breakpoint,
+      };
+    }
+
+    /**
+     * Here, we update the initial widgets
+     * This will update both layout data and widget data
+     */
+    case 'SET_INITIAL_WIDGETS': {
+      const { widgets, layouts } = action.payload;
+      return {
+        ...state,
+        widgets,
+        layouts,
+      };
+    }
+  }
+}
+
+// Helper function for updating layout sizes
+function updateLayoutSize(
+  layouts: Layout[],
+  id: string,
+  size: { w: number; h: number }
+): Layout[] {
+  return layouts.map((item) => (item.i === id ? { ...item, ...size } : item));
+}
+
+export const useWidgetReducer = () =>
+  useReducer(widgetReducer, {
+    widgets: {},
+    layouts: { sm: [], lg: [] },
+    breakpoint: 'lg',
+  });

--- a/src/app/[handle]/components/widget/grid.stories.tsx
+++ b/src/app/[handle]/components/widget/grid.stories.tsx
@@ -1,8 +1,14 @@
 import { Meta, StoryObj } from '@storybook/react';
 
 import { mockUserMinimal } from '@/api/user/mock-user';
+import { mockUserByHandleHandler } from '@/api/user/msw-handlers';
+import {
+  mockCreateWidgetHandler,
+  mockEnrichWidgetHandler,
+  mockGetWidgetsHandler,
+  mockUpdateWidgetHandler,
+} from '@/api/widgets-v2/msw-handlers';
 import { Button } from '@/components/ui/button';
-import { sleep } from '@/lib/utils';
 
 import { WidgetGrid } from './grid';
 import { useWidgets, WidgetProvider } from './use-widget-context';
@@ -12,6 +18,15 @@ const meta = {
   component: WidgetGrid,
   parameters: {
     layout: 'fullscreen',
+    msw: {
+      handlers: [
+        mockUserByHandleHandler,
+        mockGetWidgetsHandler,
+        mockUpdateWidgetHandler,
+        mockCreateWidgetHandler,
+        mockEnrichWidgetHandler,
+      ],
+    },
   },
   decorators: [
     (Story) => (
@@ -38,7 +53,7 @@ export const WithAddButton: Story = {
   render: () => {
     const { addWidget } = useWidgets();
     return (
-      <div className='size-full'>
+      <div className='size-full p-4'>
         <Button onClick={() => addWidget('https://mysorbet.io')}>
           Add widget
         </Button>
@@ -46,9 +61,4 @@ export const WithAddButton: Story = {
       </div>
     );
   },
-};
-
-const mockFetchWidgetData = async (url: string) => {
-  await sleep(3000);
-  return { contentUrl: url, iconUrl: url };
 };

--- a/src/app/[handle]/components/widget/use-widget-context.tsx
+++ b/src/app/[handle]/components/widget/use-widget-context.tsx
@@ -85,7 +85,7 @@ export function WidgetProvider({
     if (!widgets) return;
     dispatch({
       type: 'SET_INITIAL_WIDGETS',
-      payload: fromApi(widgets),
+      payload: toReducer(widgets),
     });
   }, [dispatch, widgets]);
 
@@ -379,11 +379,11 @@ export function useWidgets(): WidgetContextType {
   return context;
 }
 /**
- * Transform API widgets into the format needed by our app
- * Widgets come as an array with a layout for each breakpoint
- * We transform this into a map of widgets by id and a map of layouts by breakpoint (as the WidgetReducer expects)
+ * Transform API widgets into the format needed by the grid reducer
+ * - Widgets come as an array with a layout for each breakpoint
+ * - We transform this into a map of widgets by id and a map of layouts by breakpoint (as the WidgetReducer expects)
  */
-function fromApi(apiWidgets: ApiWidget[]): {
+function toReducer(apiWidgets: ApiWidget[]): {
   widgets: WidgetMap;
   layouts: LayoutMap;
 } {

--- a/src/app/[handle]/components/widget/use-widget-context.tsx
+++ b/src/app/[handle]/components/widget/use-widget-context.tsx
@@ -106,7 +106,7 @@ export function WidgetProvider({
 
       // Optimistic update
       dispatch({
-        type: 'ADD_WIDGET_START',
+        type: 'ADD_WIDGET',
         payload: { id, url },
       });
     },
@@ -118,14 +118,14 @@ export function WidgetProvider({
         }
         const enrichedWidget = await widgetsV2Api.enrich(id);
         dispatch({
-          type: 'ADD_WIDGET_COMPLETE',
+          type: 'UPDATE_WIDGET',
           payload: { id, data: widgetApiBoundary(enrichedWidget) },
         });
       } catch (error) {
         console.error('Failed to enrich widget:', error);
         // We failed, so this widget needs to stop loading and just be poor
         dispatch({
-          type: 'ADD_WIDGET_COMPLETE',
+          type: 'UPDATE_WIDGET',
           payload: { id, data: {} },
         });
       }
@@ -184,7 +184,7 @@ export function WidgetProvider({
       const tempUrl = URL.createObjectURL(image);
       addPending(id);
       dispatch({
-        type: 'ADD_WIDGET_START',
+        type: 'ADD_WIDGET',
         payload: { id, url: tempUrl, type: 'image' },
       });
       return { tempUrl };
@@ -196,7 +196,7 @@ export function WidgetProvider({
         URL.revokeObjectURL(context.tempUrl);
       }
       dispatch({
-        type: 'ADD_WIDGET_COMPLETE',
+        type: 'UPDATE_WIDGET',
         payload: {
           id,
           data: {
@@ -251,7 +251,7 @@ export function WidgetProvider({
       const previousWidget = state.widgets[id];
 
       dispatch({
-        type: 'ADD_WIDGET_COMPLETE',
+        type: 'UPDATE_WIDGET',
         payload: { id, data: dto },
       });
 
@@ -281,7 +281,7 @@ export function WidgetProvider({
         };
 
         dispatch({
-          type: 'ADD_WIDGET_COMPLETE',
+          type: 'UPDATE_WIDGET',
           payload: {
             id,
             data: rollbackData,

--- a/src/app/[handle]/components/widget/use-widget-context.tsx
+++ b/src/app/[handle]/components/widget/use-widget-context.tsx
@@ -1,6 +1,6 @@
 import { useMutation, useQuery } from '@tanstack/react-query';
 import axios, { isAxiosError } from 'axios';
-import React, { createContext, useContext, useReducer } from 'react';
+import React, { createContext, useContext } from 'react';
 import { type Layout } from 'react-grid-layout';
 import { toast } from 'sonner';
 import { v4 as uuidv4 } from 'uuid';
@@ -10,54 +10,19 @@ import {
   LayoutDto,
   UpdateWidgetV2Dto,
   widgetsV2Api,
-  WidgetType,
 } from '@/api/widgets-v2';
 import { uploadWidgetImage } from '@/api/widgets-v2/images';
-
 import {
-  type Breakpoint,
-  type WidgetData,
-  LayoutSizes,
-  WidgetSize,
-} from './grid-config';
+  DEFAULT_WIDGET_LAYOUT,
+  useWidgetReducer,
+} from '@/app/[handle]/components/widget/grid-reducer';
+import { LayoutMap } from '@/app/[handle]/components/widget/grid-reducer';
+import { WidgetMap } from '@/app/[handle]/components/widget/grid-reducer';
+
+import { type Breakpoint, type WidgetData, WidgetSize } from './grid-config';
 import { useAbortMap } from './use-abort-map';
 import { usePendingWidgets } from './use-pending-widgets';
 
-// Types for widget data
-type LoadableWidget = WidgetData & { loading?: boolean };
-type WidgetMap = Record<string, LoadableWidget>;
-type LayoutMap = Record<Breakpoint, Layout[]>;
-
-// Action payloads
-type AddWidgetStartPayload = { id: string; url: string; type?: WidgetType };
-type AddWidgetCompletePayload = {
-  id: string;
-  data: Omit<LoadableWidget, 'id'>;
-};
-type RemoveWidgetPayload = { id: string };
-type UpdateLayoutsPayload = { layouts: LayoutMap };
-type UpdateWidgetSizePayload = { id: string; size: WidgetSize };
-type SetBreakpointPayload = { breakpoint: Breakpoint };
-type SetInitialWidgetsPayload = { widgets: WidgetMap; layouts: LayoutMap };
-
-// Actions
-type WidgetAction =
-  | { type: 'ADD_WIDGET_START'; payload: AddWidgetStartPayload }
-  | { type: 'ADD_WIDGET_COMPLETE'; payload: AddWidgetCompletePayload }
-  | { type: 'REMOVE_WIDGET'; payload: RemoveWidgetPayload }
-  | { type: 'UPDATE_LAYOUTS'; payload: UpdateLayoutsPayload }
-  | { type: 'UPDATE_WIDGET_SIZE'; payload: UpdateWidgetSizePayload }
-  | { type: 'SET_BREAKPOINT'; payload: SetBreakpointPayload }
-  | { type: 'SET_INITIAL_WIDGETS'; payload: SetInitialWidgetsPayload };
-
-// State
-type WidgetState = {
-  widgets: WidgetMap;
-  layouts: LayoutMap;
-  breakpoint: Breakpoint;
-};
-
-// Context type
 interface WidgetContextType {
   /** Map of widget id to widget data */
   widgets: WidgetMap;
@@ -85,142 +50,6 @@ interface WidgetContextType {
 
 const WidgetContext = createContext<WidgetContextType | null>(null);
 
-const DEFAULT_WIDGET_LAYOUT = {
-  x: 0,
-  y: 0,
-  ...LayoutSizes['B'],
-};
-
-function widgetReducer(state: WidgetState, action: WidgetAction): WidgetState {
-  switch (action.type) {
-    /**
-     * Here, we add the widget to the layout right away in a loading state
-     * This is so that we can show a loading state in the UI immediately
-     * This will update both layout data and widget data
-     */
-    case 'ADD_WIDGET_START': {
-      const { id, url, type } = action.payload;
-      return {
-        ...state,
-        widgets: {
-          ...state.widgets,
-          [id]: {
-            id,
-            href: type === 'image' ? undefined : url,
-            contentUrl: type === 'image' ? url : undefined,
-            type,
-            loading: true,
-          },
-        },
-        // Add widget with default size to both breakpoints
-        layouts: {
-          sm: [{ i: id, ...DEFAULT_WIDGET_LAYOUT }, ...state.layouts.sm],
-          lg: [{ i: id, ...DEFAULT_WIDGET_LAYOUT }, ...state.layouts.lg],
-        },
-      };
-    }
-
-    /**
-     * Here, we update the widget data with the actual data from the API
-     * This will update only the widget data
-     */
-    case 'ADD_WIDGET_COMPLETE': {
-      const { id, data } = action.payload;
-      return {
-        ...state,
-        widgets: {
-          ...state.widgets,
-          [id]: {
-            ...state.widgets[id],
-            ...data,
-            loading: false,
-          },
-        },
-      };
-    }
-
-    /**
-     * Here, we remove the widget from the layout
-     * This will update both layout data and widget data
-     */
-    case 'REMOVE_WIDGET': {
-      const { id } = action.payload;
-      const { [id]: _, ...remainingWidgets } = state.widgets;
-      return {
-        ...state,
-        widgets: remainingWidgets,
-        layouts: {
-          sm: state.layouts.sm.filter((item) => item.i !== id),
-          lg: state.layouts.lg.filter((item) => item.i !== id),
-        },
-      };
-    }
-
-    /**
-     * Here, we just replace all layouts with the new ones (usually reported by rgl)
-     * This will update only the layout data
-     */
-    case 'UPDATE_LAYOUTS': {
-      return {
-        ...state,
-        layouts: action.payload.layouts,
-      };
-    }
-
-    /**
-     * Here, we update the size of a widget
-     * This will update only the layout data
-     */
-    case 'UPDATE_WIDGET_SIZE': {
-      const { id, size } = action.payload;
-      return {
-        ...state,
-        layouts: {
-          ...state.layouts,
-          [state.breakpoint]: updateLayoutSize(
-            state.layouts[state.breakpoint],
-            id,
-            LayoutSizes[size]
-          ),
-        },
-      };
-    }
-
-    /**
-     * Here, we update the current breakpoint
-     * We just need to maintain this state for RGL (and since we base some calculations on it)
-     */
-    case 'SET_BREAKPOINT': {
-      return {
-        ...state,
-        breakpoint: action.payload.breakpoint,
-      };
-    }
-
-    /**
-     * Here, we update the initial widgets
-     * This will update both layout data and widget data
-     */
-    case 'SET_INITIAL_WIDGETS': {
-      const { widgets, layouts } = action.payload;
-      return {
-        ...state,
-        widgets,
-        layouts,
-      };
-    }
-  }
-}
-
-// Helper function for updating layout sizes
-function updateLayoutSize(
-  layouts: Layout[],
-  id: string,
-  size: { w: number; h: number }
-): Layout[] {
-  return layouts.map((item) => (item.i === id ? { ...item, ...size } : item));
-}
-
 /**
  * Provides state and operations for widgets in an RGL grid.
  */
@@ -232,11 +61,7 @@ export function WidgetProvider({
   userId: string;
 }) {
   // The widget reducer manages grid state
-  const [state, dispatch] = useReducer(widgetReducer, {
-    widgets: {},
-    layouts: { sm: [], lg: [] },
-    breakpoint: 'lg',
-  });
+  const [state, dispatch] = useWidgetReducer();
 
   // This is a little hack to keep track of the ids of widgets that have been added to UI, but we don't know if the API
   // has returned successfully. When layout changes happen, we choose not to update layouts for these widgets.
@@ -262,7 +87,7 @@ export function WidgetProvider({
       type: 'SET_INITIAL_WIDGETS',
       payload: fromApi(widgets),
     });
-  }, [widgets]);
+  }, [dispatch, widgets]);
 
   // Widget creation mutation
   const createWidgetMutation = useMutation({
@@ -564,6 +389,11 @@ export function useWidgets(): WidgetContextType {
   return context;
 }
 
+/**
+ * We run widgets we get from the API through this boundary function
+ * We transform most nulls to undefined, save for explicitly 'clearable' fields
+ * TODO: we should probably just leave nulls alone and use nulls in the reducer
+ */
 const widgetApiBoundary = (widget: ApiWidget): WidgetData => {
   return {
     id: widget.id,
@@ -578,6 +408,8 @@ const widgetApiBoundary = (widget: ApiWidget): WidgetData => {
 
 /**
  * Transform API widgets into the format needed by our app
+ * Widgets come as an array with a layout for each breakpoint
+ * We transform this into a map of widgets by id and a map of layouts by breakpoint (as the WidgetReducer expects)
  */
 function fromApi(apiWidgets: ApiWidget[]): {
   widgets: WidgetMap;

--- a/src/app/[handle]/components/widget/widget.stories.tsx
+++ b/src/app/[handle]/components/widget/widget.stories.tsx
@@ -1,4 +1,5 @@
 import { Meta, StoryFn, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
 
 import { WidgetSize } from './grid-config';
 import { UrlType, UrlTypes } from './url-util';
@@ -35,6 +36,26 @@ const meta = {
   component: Widget,
   parameters: {
     layout: 'centered',
+  },
+  args: {
+    onUpdate: fn(),
+  },
+  argTypes: {
+    size: {
+      control: {
+        type: 'select',
+      },
+    },
+    type: {
+      control: {
+        type: 'select',
+      },
+    },
+    onUpdate: {
+      table: {
+        disable: true,
+      },
+    },
   },
   decorators: [withSizeContainer],
 } satisfies Meta<typeof Widget>;
@@ -85,14 +106,14 @@ export const E: Story = {
   },
 };
 
-export const WithIcon: Story = {
+export const WithContent: Story = {
   args: {
     ...Default.args,
     ...urls,
   },
 };
 
-export const WithIconAndLongTitle: Story = {
+export const WithContentAndLongTitle: Story = {
   args: {
     ...Default.args,
     ...urls,

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -2,21 +2,22 @@ import { Link } from 'lucide-react';
 import React from 'react';
 import { parseURL } from 'ufo';
 
+import { UpdateWidgetDto, WidgetData } from '@/api/widgets-v2';
+import { WidgetSize } from '@/app/[handle]/components/widget/grid-config';
 import { InlineEdit } from '@/components/common/inline-edit/inline-edit';
 import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 
-import { WidgetData, WidgetSize } from './grid-config';
 import { ImageWidget } from './image-widget';
 import { SocialIcon } from './social-icon';
 import { getUrlType } from './url-util';
 
-export type WidgetProps = Omit<WidgetData, 'id'> & {
+export type WidgetProps = Partial<Omit<WidgetData, 'id'>> & {
   loading?: boolean;
   size: WidgetSize;
   editable?: boolean;
-  onUpdate?: (data: Partial<WidgetData>) => void;
+  onUpdate?: (data: UpdateWidgetDto) => void;
   showPlaceholder?: boolean;
 };
 
@@ -30,20 +31,25 @@ export type WidgetProps = Omit<WidgetData, 'id'> & {
  * They are expected to be rendered in a container with a width and height corresponding to the the `size` prop.
  */
 export const Widget = ({
-  iconUrl,
-  title,
-  userTitle,
-  contentUrl,
   loading = false,
-  type,
   size = 'A',
   editable = false,
   onUpdate,
   showPlaceholder = true,
   ...props
 }: WidgetProps) => {
-  // This is a little hack because we made href nullable. (which we had to do since we need it to be nullable in the reducer)
-  const href = props.href ?? undefined;
+  // We store widgets state as nullable for good reason.
+  // So the easiest way to handle this is to just accept null and undefined props.
+  // And convert here for convenience below.
+  const { href, contentUrl, iconUrl, title, userTitle, type } = {
+    href: props.href ?? undefined,
+    contentUrl: props.contentUrl ?? undefined,
+    iconUrl: props.iconUrl ?? undefined,
+    title: props.title ?? undefined,
+    userTitle: props.userTitle ?? undefined,
+    type: props.type ?? undefined,
+  };
+
   if (type === 'image') {
     return (
       <ImageWidget


### PR DESCRIPTION
**Changes**
- Grid reducer will store nulls rather than undefined 
- move widget reducer to its own file
- use more appropriate names for reducer actions
- Add two E sized widgets to samples
- Consolidate and relocate WidgetData and UpdateDto
- Make grid story functional
- Clean up widget story