### PR TITLE
U/dc/widget-refactor

### DIFF
--- a/src/api/widgets-v2/mock-widgets.ts
+++ b/src/api/widgets-v2/mock-widgets.ts
@@ -75,7 +75,6 @@ export const mockWidgetData: Record<string, WidgetData> = {
     ...nulls,
     id: 'h',
     title: 'Widget 8',
-    contentUrl: 'https://picsum.photos/550/550?grayscale',
     href: 'https://picsum.photos/550/550?grayscale',
     iconUrl: 'https://picsum.photos/32/32?grayscale',
   },

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -97,7 +97,7 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
                 key={widget.id}
                 dragging={isDragging}
                 setIsDragging={setIsDragging}
-                className='group relative'
+                className='group/widget'
               >
                 <Widget
                   {...widget}
@@ -206,7 +206,7 @@ const ControlOverlay = ({
         className={cn(
           'absolute bottom-0 left-1/2 w-fit -translate-x-1/2 translate-y-1/2', // position
           'opacity-0 transition-opacity duration-300', // opacity
-          !dragging && 'group-hover:opacity-100', // hover (only if not dragged)
+          !dragging && 'group-hover/widget:opacity-100', // hover (only if not dragged)
           isPopoverOpen && 'opacity-100' // show when popover is open
         )}
         onMouseDown={(e) => e.stopPropagation()}
@@ -225,7 +225,7 @@ const ControlOverlay = ({
         className={cn(
           'absolute right-0 top-0 -translate-y-1/3 translate-x-1/3', // position
           'opacity-0 transition-opacity duration-300', // opacity
-          !dragging && 'group-hover:opacity-100', // hover (only if not dragged)
+          !dragging && 'group-hover/widget:opacity-100', // hover (only if not dragged)
           isPopoverOpen && 'opacity-100' // show when popover is open
         )}
         onMouseDown={(e) => e.stopPropagation()}

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -188,19 +188,19 @@ const Icon: React.FC<
 };
 
 const ContentPlaceholder = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
 >(({ className, ...rest }, ref) => {
   return (
     <div
       className={cn(
-        'bg-muted text-muted-foreground group flex items-center justify-center rounded-md border p-2 text-center text-sm font-normal',
+        'bg-muted text-muted-foreground group/placeholder flex items-center justify-center rounded-md border p-2 text-center text-sm font-normal',
         className
       )}
       ref={ref}
       {...rest}
     >
-      <p className='opacity-0 transition-opacity duration-500 group-hover:opacity-100'>
+      <p className='opacity-0 transition-opacity duration-500 group-hover/placeholder:opacity-100'>
         We couldn't find a preview for this link
       </p>
     </div>

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -70,7 +70,7 @@ export const Widget = ({
   return (
     <a
       className={cn(
-        'bg-card text-card-foreground flex select-none flex-col overflow-hidden rounded-2xl border shadow-sm',
+        'bg-card text-card-foreground flex select-none flex-col overflow-clip rounded-2xl border shadow-sm',
         size === 'D' && 'flex-row',
         size === 'E' && 'justify-center',
         'size-full max-h-[390px] max-w-[390px]',

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -108,7 +108,8 @@ export const Widget = ({
             value={userTitle || fallbackTitle}
             editable={editable}
             onChange={(value) => {
-              onUpdate?.({ userTitle: value === '' ? null : value }); // If the user clears the title, set it to null to explicitly clear it
+              // If the user clears the title, set it to null to explicitly clear it
+              onUpdate?.({ userTitle: value === '' ? null : value });
             }}
             placeholder={fallbackTitle}
             className={cn(
@@ -120,49 +121,32 @@ export const Widget = ({
           />
         </CardTitle>
       </CardHeader>
-      {/* TODO: Perhaps you could extract all the size conditionals to this container? */}
-      {size !== 'E' && (
+      {size !== 'E' && size !== 'B' && (
         <CardContent
           className={cn(
             'flex flex-1 items-end justify-end',
             size === 'D' && 'pl-0 pt-6'
           )}
         >
-          {size !== 'B' && (
-            <>
-              {loading ? (
-                <Skeleton
-                  className={cn(
-                    size === 'A' && 'aspect-[1200/630] w-full', // common og image aspect
-                    size === 'C' && 'aspect-square w-full',
-                    size === 'D' && 'aspect-square h-full'
-                  )}
-                />
-              ) : contentUrl ? (
-                <img
-                  src={contentUrl}
-                  alt={title}
-                  className={cn(
-                    'rounded-md object-cover',
-                    size === 'A' && 'aspect-[1200/630] w-full', // common og image aspect
-                    // B doesn't have a content image
-                    size === 'C' && 'aspect-square w-full',
-                    size === 'D' && 'aspect-square h-full'
-                  )}
-                />
-              ) : (
-                showPlaceholder && (
-                  <ContentPlaceholder
-                    className={cn(
-                      size === 'A' && 'aspect-[1200/630] w-full',
-                      size === 'C' && 'aspect-square w-full',
-                      size === 'D' && 'aspect-square h-full'
-                    )}
-                  />
-                )
-              )}
-            </>
-          )}
+          <div
+            className={cn(
+              size === 'A' && 'aspect-[1200/630] w-full',
+              size === 'C' && 'aspect-square w-full',
+              size === 'D' && 'aspect-square h-full'
+            )}
+          >
+            {loading ? (
+              <Skeleton className='size-full' />
+            ) : contentUrl ? (
+              <img
+                src={contentUrl}
+                alt={title}
+                className='size-full rounded-md object-cover'
+              />
+            ) : showPlaceholder ? (
+              <ContentPlaceholder className='size-full' />
+            ) : null}
+          </div>
         </CardContent>
       )}
     </a>

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -113,9 +113,9 @@ export const Widget = ({
             }}
             placeholder={fallbackTitle}
             className={cn(
-              'line-clamp-3 break-words',
+              '-ml-2 line-clamp-3 break-words px-2 py-1',
               editable &&
-                'hover:bg-muted -ml-2 rounded-sm px-2 py-1 transition-colors duration-200',
+                'hover:bg-muted rounded-sm transition-colors duration-200',
               size === 'E' && 'm-0 line-clamp-1'
             )}
           />

--- a/src/components/common/inline-edit/inline-edit.tsx
+++ b/src/components/common/inline-edit/inline-edit.tsx
@@ -42,18 +42,13 @@ export const InlineEdit = ({
   };
 
   const handleClick = (e: React.MouseEvent) => {
-    // Always prevent parent link activation
-    e.preventDefault();
-    e.stopPropagation();
+    // If this is an editable text, prevent parent events
+    // Otherwise, we want to allow the parent to handle the click event
+    editable && e.preventDefault();
 
     if (editable && !isEditing) {
       setIsEditing(true);
     }
-  };
-
-  const handleMouseDown = (e: React.MouseEvent) => {
-    // Prevent parent link activation but allow text selection
-    e.stopPropagation();
   };
 
   // Update local state when prop value changes
@@ -64,7 +59,6 @@ export const InlineEdit = ({
   return (
     <div
       onClick={handleClick}
-      onMouseDown={handleMouseDown}
       className={cn(editable && 'cursor-text', className)}
     >
       {editable && isEditing ? (


### PR DESCRIPTION
**Changes**
- Simplify internal widget classnames
- Fix layout shift between editable and not
- Fix a bug preventing widgets from being dragged or clicked through their text
- Fix a bug where hovering a widget would hover its placeholder
- Add a placeholder widget to mock widgets