### PR TITLE
[SRBT-432] Implement Preview Controls

### DIFF
--- a/src/api/widgets-v2/mock-widgets.ts
+++ b/src/api/widgets-v2/mock-widgets.ts
@@ -11,6 +11,8 @@ const nulls: Omit<WidgetData, 'id'> = {
   custom: null,
   contentUrl: null,
   href: null,
+  userContentUrl: null,
+  hideContent: false,
 };
 
 export const mockWidgetData: Record<string, WidgetData> = {
@@ -54,6 +56,7 @@ export const mockWidgetData: Record<string, WidgetData> = {
     id: 'e',
     title: 'Widget 5',
     contentUrl: 'https://picsum.photos/500/250?grayscale',
+    userContentUrl: 'https://picsum.photos/500/250',
     href: 'https://picsum.photos/500/250?grayscale',
     iconUrl: 'https://picsum.photos/32/32?grayscale',
   },
@@ -112,6 +115,8 @@ export const sampleWidget: ApiWidget = {
   ],
   type: null,
   custom: null,
+  userContentUrl: null,
+  hideContent: false,
 };
 
 export const mockWidgets: ApiWidget[] = Object.values(mockWidgetData).map(

--- a/src/api/widgets-v2/mock-widgets.ts
+++ b/src/api/widgets-v2/mock-widgets.ts
@@ -3,21 +3,21 @@ import { WidgetData } from '@/api/widgets-v2/types';
 import { sampleLayoutLg, sampleLayoutSm } from './sample-layout';
 import { ApiWidget } from './types';
 
-const nulls: Omit<WidgetData, 'id'> = {
+const defaults: Omit<WidgetData, 'id'> = {
   title: null,
   userTitle: null,
   iconUrl: null,
   type: null,
   custom: null,
   contentUrl: null,
-  href: null,
   userContentUrl: null,
   hideContent: false,
+  href: null,
 };
 
 export const mockWidgetData: Record<string, WidgetData> = {
   a: {
-    ...nulls,
+    ...defaults,
     id: 'a',
     title: 'Widget 1',
     contentUrl: 'https://picsum.photos/400/300?grayscale',
@@ -26,7 +26,7 @@ export const mockWidgetData: Record<string, WidgetData> = {
     userTitle: 'User Title 1',
   },
   b: {
-    ...nulls,
+    ...defaults,
     id: 'b',
     title: 'Widget 2',
     contentUrl: 'https://picsum.photos/300/400?grayscale',
@@ -37,7 +37,7 @@ export const mockWidgetData: Record<string, WidgetData> = {
     custom: null,
   },
   c: {
-    ...nulls,
+    ...defaults,
     id: 'c',
     title: 'Widget 3',
     contentUrl: 'https://picsum.photos/350/350?grayscale',
@@ -45,14 +45,14 @@ export const mockWidgetData: Record<string, WidgetData> = {
     iconUrl: 'https://picsum.photos/32/32?grayscale',
   },
   d: {
-    ...nulls,
+    ...defaults,
     id: 'd',
     contentUrl: 'https://picsum.photos/450/300?grayscale',
     href: 'https://picsum.photos/450/300?grayscale',
     type: 'image',
   },
   e: {
-    ...nulls,
+    ...defaults,
     id: 'e',
     title: 'Widget 5',
     contentUrl: 'https://picsum.photos/500/250?grayscale',
@@ -61,13 +61,13 @@ export const mockWidgetData: Record<string, WidgetData> = {
     iconUrl: 'https://picsum.photos/32/32?grayscale',
   },
   f: {
-    ...nulls,
+    ...defaults,
     id: 'f',
     contentUrl: 'https://picsum.photos/400/400?grayscale',
     type: 'image',
   },
   g: {
-    ...nulls,
+    ...defaults,
     id: 'g',
     title: 'Widget 7',
     contentUrl: 'https://picsum.photos/600/600?grayscale',
@@ -75,14 +75,14 @@ export const mockWidgetData: Record<string, WidgetData> = {
     iconUrl: 'https://picsum.photos/32/32?grayscale',
   },
   h: {
-    ...nulls,
+    ...defaults,
     id: 'h',
     title: 'Widget 8',
     href: 'https://picsum.photos/550/550?grayscale',
     iconUrl: 'https://picsum.photos/32/32?grayscale',
   },
   i: {
-    ...nulls,
+    ...defaults,
     id: 'i',
     title: 'Widget 9',
     contentUrl: 'https://picsum.photos/600/600?grayscale',
@@ -90,7 +90,7 @@ export const mockWidgetData: Record<string, WidgetData> = {
     iconUrl: 'https://picsum.photos/32/32?grayscale',
   },
   j: {
-    ...nulls,
+    ...defaults,
     id: 'j',
     title: 'Widget 10',
     contentUrl: 'https://picsum.photos/600/600?grayscale',
@@ -105,6 +105,8 @@ export const sampleWidget: ApiWidget = {
   userTitle: 'Sample User Title',
   iconUrl: 'https://placehold.co/32/orange/white',
   contentUrl: 'https://placehold.co/400/orange/white',
+  userContentUrl: null,
+  hideContent: false,
   href: 'https://example.com',
   createdAt: new Date(),
   updatedAt: new Date(),
@@ -115,8 +117,6 @@ export const sampleWidget: ApiWidget = {
   ],
   type: null,
   custom: null,
-  userContentUrl: null,
-  hideContent: false,
 };
 
 export const mockWidgets: ApiWidget[] = Object.values(mockWidgetData).map(

--- a/src/api/widgets-v2/msw-handlers.ts
+++ b/src/api/widgets-v2/msw-handlers.ts
@@ -114,7 +114,7 @@ export const mockImageUploadHandler = http.post(
   async ({ request }) => {
     const formData = await request.formData();
     const _file = formData.get('file') as File;
-    await delay();
+    await delay(4000);
     return HttpResponse.json({
       fileUrl: 'https://placehold.co/400/orange/white',
     });

--- a/src/api/widgets-v2/msw-handlers.ts
+++ b/src/api/widgets-v2/msw-handlers.ts
@@ -73,12 +73,8 @@ export const mockUpdateWidgetHandler = http.put(
 
     return HttpResponse.json({
       ...previousWidget,
+      ...updateData,
       id: id as string,
-      title: updateData.title,
-      contentUrl: updateData.contentUrl,
-      custom: updateData.custom,
-      userTitle: updateData.userTitle,
-      href: updateData.href,
       updatedAt: new Date(),
     });
   }
@@ -109,6 +105,18 @@ export const mockEnrichWidgetHandler = http.post(
       contentUrl: 'https://placehold.co/400/orange/white',
       href: 'https://example.com',
       updatedAt: new Date(),
+    });
+  }
+);
+
+export const mockImageUploadHandler = http.post(
+  `${env.NEXT_PUBLIC_SORBET_API_URL}/images/widgets`,
+  async ({ request }) => {
+    const formData = await request.formData();
+    const _file = formData.get('file') as File;
+    await delay();
+    return HttpResponse.json({
+      fileUrl: 'https://placehold.co/400/orange/white',
     });
   }
 );

--- a/src/api/widgets-v2/sample-layout.ts
+++ b/src/api/widgets-v2/sample-layout.ts
@@ -3,8 +3,10 @@ import { Layout } from 'react-grid-layout';
 import { WidgetData } from '@/api/widgets-v2/types';
 import { Breakpoint } from '@/app/[handle]/components/widget/grid-config';
 
-const nulls: Omit<WidgetData, 'id'> = {
+const defaults: Omit<WidgetData, 'id'> = {
   contentUrl: null,
+  userContentUrl: null,
+  hideContent: false,
   href: null,
   iconUrl: null,
   title: null,
@@ -14,16 +16,16 @@ const nulls: Omit<WidgetData, 'id'> = {
 };
 
 export const sampleWidgetsMap: Record<string, WidgetData> = {
-  a: { ...nulls, id: 'a', title: 'Widget A' },
-  b: { ...nulls, id: 'b', title: 'Widget B' },
-  c: { ...nulls, id: 'c', title: 'Widget C' },
-  d: { ...nulls, id: 'd', title: 'Widget D' },
-  e: { ...nulls, id: 'e', title: 'Widget E' },
-  f: { ...nulls, id: 'f', title: 'Widget F' },
-  g: { ...nulls, id: 'g', title: 'Widget G' },
-  h: { ...nulls, id: 'h', title: 'Widget H' },
-  i: { ...nulls, id: 'i', title: 'Widget I' },
-  j: { ...nulls, id: 'j', title: 'Widget J' },
+  a: { ...defaults, id: 'a', title: 'Widget A' },
+  b: { ...defaults, id: 'b', title: 'Widget B' },
+  c: { ...defaults, id: 'c', title: 'Widget C' },
+  d: { ...defaults, id: 'd', title: 'Widget D' },
+  e: { ...defaults, id: 'e', title: 'Widget E' },
+  f: { ...defaults, id: 'f', title: 'Widget F' },
+  g: { ...defaults, id: 'g', title: 'Widget G' },
+  h: { ...defaults, id: 'h', title: 'Widget H' },
+  i: { ...defaults, id: 'i', title: 'Widget I' },
+  j: { ...defaults, id: 'j', title: 'Widget J' },
 };
 
 export const sampleLayoutLg: Layout[] = [

--- a/src/api/widgets-v2/types.ts
+++ b/src/api/widgets-v2/types.ts
@@ -49,6 +49,8 @@ export type ApiWidget = {
   userTitle: string | null;
   iconUrl: string | null;
   contentUrl: string | null;
+  userContentUrl: string | null;
+  hideContent: boolean;
   type: WidgetType | null;
   custom: Record<string, unknown> | null;
   createdAt: Date;
@@ -66,6 +68,8 @@ export type WidgetData = Pick<
   | 'userTitle'
   | 'iconUrl'
   | 'contentUrl'
+  | 'userContentUrl'
+  | 'hideContent'
   | 'type'
   | 'custom'
 >;

--- a/src/api/widgets-v2/types.ts
+++ b/src/api/widgets-v2/types.ts
@@ -76,6 +76,8 @@ export type WidgetData = Pick<
 
 /**
  * This is the shape of the data used to update a widget
- * You can update anything we store besides id
+ * You can update anything we store besides id, iconUrl, or type (match backend DTO)
  */
-export type UpdateWidgetDto = Partial<Omit<WidgetData, 'id'>>;
+export type UpdateWidgetDto = Partial<
+  Omit<WidgetData, 'id' | 'iconUrl' | 'type'>
+>;

--- a/src/app/[handle]/components/control-bar/add-image-button.tsx
+++ b/src/app/[handle]/components/control-bar/add-image-button.tsx
@@ -14,6 +14,8 @@ import {
 } from '@/components/ui/tooltip';
 import { cn } from '@/lib/utils';
 
+import { InvisibleInput } from './invisible-input';
+
 // TODO: Make sure this is accessible, has the right role, etc.
 // TODO: Is the input nested within a label really the best approach here?
 
@@ -43,27 +45,17 @@ export const AddImageButton = ({
   return (
     <Tooltip>
       <TooltipTrigger asChild>
-        <label
-          htmlFor='upload-image'
-          tabIndex={0}
-          onKeyDown={(e) => {
-            e.key === 'Enter' && e.currentTarget.click();
-          }}
-          // TODO: These styles are duplicates of the ControlBarIconButton, but we need to apply them to the label for this to work. Any options?
+        <InvisibleInput
+          handleInputChange={handleInputChange}
+          inputProps={{ accept: validImageExtensionsWithDots.join(',') }}
           className={cn(
+            // TODO: These styles are duplicates of the ControlBarIconButton, but we need to apply them to the label for this to work. Any options?
             buttonVariants({ variant: 'secondary' }),
             'h-fit cursor-pointer border border-[#E5E7EB] p-1 transition-transform hover:scale-110'
           )}
         >
-          <input
-            id='upload-image'
-            type='file'
-            className='hidden'
-            onChange={handleInputChange}
-            accept={validImageExtensionsWithDots.join(',')}
-          />
           <ImageIcon aria-hidden='true' />
-        </label>
+        </InvisibleInput>
       </TooltipTrigger>
       <TooltipContent>Add an image</TooltipContent>
     </Tooltip>

--- a/src/app/[handle]/components/control-bar/invisible-input.tsx
+++ b/src/app/[handle]/components/control-bar/invisible-input.tsx
@@ -1,0 +1,39 @@
+import { forwardRef, useId } from 'react';
+
+/**
+ * Wrap your component in this to make it act like a file input.
+ */
+export const InvisibleInput = forwardRef<
+  HTMLLabelElement,
+  {
+    children: React.ReactNode;
+    handleInputChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
+    className?: string;
+    inputProps?: React.InputHTMLAttributes<HTMLInputElement>;
+  }
+>(({ children, handleInputChange, className, inputProps, ...props }, ref) => {
+  const id = useId();
+  return (
+    <label
+      ref={ref}
+      htmlFor={id}
+      tabIndex={0}
+      onKeyDown={(e) => {
+        e.key === 'Enter' && e.currentTarget.click();
+      }}
+      className={className}
+      {...props}
+    >
+      <input
+        id={id}
+        type='file'
+        className='hidden'
+        onChange={handleInputChange}
+        {...inputProps}
+      />
+      {children}
+    </label>
+  );
+});
+
+InvisibleInput.displayName = 'InvisibleInput';

--- a/src/app/[handle]/components/profile.stories.tsx
+++ b/src/app/[handle]/components/profile.stories.tsx
@@ -62,7 +62,9 @@ export const Mine: Story = {
 export const MineDisableMSW: Story = {
   name: 'Mine (Disable MSW)',
   parameters: {
-    msw: undefined,
+    msw: {
+      handlers: [],
+    },
   },
   args: {
     user: mockUser,

--- a/src/app/[handle]/components/profile.stories.tsx
+++ b/src/app/[handle]/components/profile.stories.tsx
@@ -3,6 +3,7 @@ import { Meta, StoryObj } from '@storybook/react';
 import { mockUser, mockUserByHandleHandler } from '@/api/user';
 import {
   mockGetWidgetsHandler,
+  mockImageUploadHandler,
   mockUpdateWidgetHandler,
 } from '@/api/widgets-v2';
 
@@ -20,6 +21,7 @@ const meta = {
         mockUserByHandleHandler,
         mockGetWidgetsHandler,
         mockUpdateWidgetHandler,
+        mockImageUploadHandler,
       ],
     },
   },

--- a/src/app/[handle]/components/profile.stories.tsx
+++ b/src/app/[handle]/components/profile.stories.tsx
@@ -15,7 +15,6 @@ const meta = {
   component: Profile,
   parameters: {
     layout: 'fullscreen',
-    // Comment MSW to hit the local API
     msw: {
       handlers: [
         mockUserByHandleHandler,
@@ -53,6 +52,18 @@ export const LoggedIn: Story = {
 };
 
 export const Mine: Story = {
+  args: {
+    user: mockUser,
+    isMine: true,
+    isLoggedIn: true,
+  },
+};
+
+export const MineDisableMSW: Story = {
+  name: 'Mine (Disable MSW)',
+  parameters: {
+    msw: undefined,
+  },
   args: {
     user: mockUser,
     isMine: true,

--- a/src/app/[handle]/components/widget/grid-reducer.tsx
+++ b/src/app/[handle]/components/widget/grid-reducer.tsx
@@ -6,7 +6,10 @@ import { UpdateWidgetDto, WidgetData, WidgetType } from '@/api/widgets-v2';
 import { type Breakpoint, LayoutSizes, WidgetSize } from './grid-config';
 
 // Types for state
-type LoadableWidget = WidgetData & { loading?: boolean };
+type LoadableWidget = WidgetData & {
+  loading?: boolean;
+  previewLoading?: boolean; // Specifically indicates a preview loading from an update (not initial load)
+};
 export type WidgetMap = Record<string, LoadableWidget>;
 export type LayoutMap = Record<Breakpoint, Layout[]>;
 
@@ -14,7 +17,7 @@ export type LayoutMap = Record<Breakpoint, Layout[]>;
 type AddWidgetPayload = { id: string; url: string; type?: WidgetType };
 type UpdateWidgetPayload = {
   id: string;
-  data: UpdateWidgetDto;
+  data: UpdateWidgetDto & { previewLoading?: boolean };
 };
 type RemoveWidgetPayload = { id: string };
 type UpdateLayoutsPayload = { layouts: LayoutMap };
@@ -75,6 +78,8 @@ function gridReducer(state: GridState, action: GridAction): GridState {
             userTitle: null,
             iconUrl: null,
             custom: null,
+            hideContent: false,
+            userContentUrl: null,
             loading: true,
           },
         },

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -205,6 +205,10 @@ const ControlOverlay = ({
   const showPreviewControls =
     size !== 'B' && size !== 'E' && !controls?.includes('link');
 
+  // const showDeletePreview = !widget.hideContent
+  // const showRevert = widget.userContentUrl !== null || (widget.contentUrl !== null && widget.hideContent)
+  // const showUpload = true // always can upload a new image
+
   // Containers implement hover behavior and position absolutely
   return (
     <>

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -205,19 +205,17 @@ const ControlOverlay = ({
   const showPreviewControls =
     size !== 'B' && size !== 'E' && !controls?.includes('link');
 
-  // const handleDelete = () => {
-  //   toast('Deleting image');
-  //   updateWidget(id, { userContentUrl: null, hideContent: true });
-  // };
   // const handleUpload = (image) => {
   //   // set contentUrl to local url, set image loading to true, do upload, and replace url when done
   //   updatePreview(id, { image });
   //   toast('Uploading image');
   // };
-  // const handleRevert = () => {
-  //   toast('Reverting image');
-  //   updateWidget(id, { userContentUrl: null, hideContent: false });
-  // };
+  const handleDelete = () => {
+    updateWidget(id, { userContentUrl: null, hideContent: true });
+  };
+  const handleRevert = () => {
+    updateWidget(id, { userContentUrl: null, hideContent: false });
+  };
 
   // Containers implement hover behavior and position absolutely
   return (
@@ -260,14 +258,10 @@ const ControlOverlay = ({
         {showPreviewControls && (
           <PreviewControls
             onUpload={() => {
-              toast('upload');
+              toast('Stub: image ready for upload');
             }}
-            onRevert={() => {
-              toast('revert');
-            }}
-            onDelete={() => {
-              toast('delete');
-            }}
+            onRevert={handleRevert}
+            onDelete={handleDelete}
           />
         )}
       </div>

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -206,7 +206,8 @@ const ControlOverlay = ({
   const { id, href, hideContent, userContentUrl, contentUrl } = widget;
 
   // Build conditionally available functions to handle actions on the preview controls as well as control their visibility
-  const showDelete = !hideContent;
+  const showDelete =
+    !hideContent && (contentUrl !== null || userContentUrl !== null);
   const showRevert =
     userContentUrl !== null || (contentUrl !== null && hideContent);
   const showUpload = true; // always can upload a new image

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -3,7 +3,6 @@ import 'react-resizable/css/styles.css';
 
 import React, { useEffect, useState } from 'react';
 import { Responsive as RRGL } from 'react-grid-layout';
-import { toast } from 'sonner';
 
 import { PreviewControls } from '@/app/[handle]/components/widget/widget-controls/preview-controls';
 import { useContainerQuery } from '@/hooks/use-container-query';
@@ -199,23 +198,12 @@ const ControlOverlay = ({
   href?: string | null;
   controls?: Control[];
 }) => {
-  const { updateSize, removeWidget, updateWidget } = useWidgets();
+  const { updateSize, removeWidget, updateWidget, updatePreview } =
+    useWidgets();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
   const showPreviewControls =
     size !== 'B' && size !== 'E' && !controls?.includes('link');
-
-  // const handleUpload = (image) => {
-  //   // set contentUrl to local url, set image loading to true, do upload, and replace url when done
-  //   updatePreview(id, { image });
-  //   toast('Uploading image');
-  // };
-  const handleDelete = () => {
-    updateWidget(id, { userContentUrl: null, hideContent: true });
-  };
-  const handleRevert = () => {
-    updateWidget(id, { userContentUrl: null, hideContent: false });
-  };
 
   // Containers implement hover behavior and position absolutely
   return (
@@ -257,11 +245,13 @@ const ControlOverlay = ({
       >
         {showPreviewControls && (
           <PreviewControls
-            onUpload={() => {
-              toast('Stub: image ready for upload');
-            }}
-            onRevert={handleRevert}
-            onDelete={handleDelete}
+            onUpload={(image) => updatePreview(id, image)}
+            onRevert={() =>
+              updateWidget(id, { userContentUrl: null, hideContent: false })
+            }
+            onDelete={() =>
+              updateWidget(id, { userContentUrl: null, hideContent: true })
+            }
           />
         )}
       </div>

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -46,7 +46,7 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
   const width = gw(breakpoint);
 
   // Part of a little trick to allow both clicking and dragging on rgl children
-  const [isDragging, setIsDragging] = useState<boolean>(false);
+  const [dragging, setDragging] = useState(false);
 
   // This trick puts us in control of the breakpoint via a container query rather than
   // setting up a width listener on the grid and relying on that to trigger onBreakpointChange
@@ -80,7 +80,7 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
           breakpoints={breakpoints}
           breakpoint={breakpoint}
           onLayoutChange={onLayoutChange}
-          onDrag={() => setIsDragging(true)}
+          onDrag={() => setDragging(true)}
         >
           {layouts[breakpoint].map((layout) => {
             const widget = widgets[layout.i];
@@ -96,14 +96,14 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
             return (
               <RGLHandle
                 key={widget.id}
-                dragging={isDragging}
-                setIsDragging={setIsDragging}
+                dragging={dragging}
+                setDragging={setDragging}
                 className='group/widget'
               >
                 <Widget
                   {...widget}
                   size={s}
-                  isDragging={isDragging}
+                  dragging={dragging}
                   editable={!immutable}
                   showPlaceholder={!immutable}
                   onUpdate={(data) => updateWidget(widget.id, data)}
@@ -112,7 +112,7 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
                   <ControlOverlay
                     widget={widget}
                     size={s}
-                    dragging={isDragging}
+                    dragging={dragging}
                     controls={
                       widget.type === 'image' ? ImageControls : undefined
                     }
@@ -131,7 +131,7 @@ interface RGLHandleProps extends React.HTMLAttributes<HTMLDivElement> {
   children?: React.ReactNode;
   debug?: boolean;
   dragging: boolean;
-  setIsDragging: (dragging: boolean) => void;
+  setDragging: (dragging: boolean) => void;
 }
 
 /**
@@ -150,7 +150,7 @@ const RGLHandle = React.forwardRef<HTMLDivElement, RGLHandleProps>(
       children,
       debug = false,
       dragging,
-      setIsDragging,
+      setDragging,
       ...props
     },
     ref
@@ -167,8 +167,8 @@ const RGLHandle = React.forwardRef<HTMLDivElement, RGLHandleProps>(
         onMouseUp={onMouseUp}
         onTouchEnd={onTouchEnd}
         onClick={(e) => {
-          if (dragging) e.preventDefault();
-          setIsDragging(false);
+          dragging && e.preventDefault();
+          setDragging(false);
         }}
         {...props}
       >

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -94,7 +94,7 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
             }
             const s = size(layout.w, layout.h);
             return (
-              <RGLHandle
+              <RGLNode
                 key={widget.id}
                 dragging={dragging}
                 setDragging={setDragging}
@@ -118,7 +118,7 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
                     }
                   />
                 )}
-              </RGLHandle>
+              </RGLNode>
             );
           })}
         </RRGL>
@@ -127,45 +127,34 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
   );
 };
 
-interface RGLHandleProps extends React.HTMLAttributes<HTMLDivElement> {
-  children?: React.ReactNode;
-  debug?: boolean;
-  dragging: boolean;
-  setDragging: (dragging: boolean) => void;
-}
-
 /**
- * This should be the direct child mapped inside RGL. We forward all necessary props this way. We also add some special sauce to make click events work correctly.
+ * This should be the direct child mapped inside RGL. This component:
+ * 1. Forwards a ref to the underlying DOM node
+ * 2. Forwards `style`, `className` (through cn), `onMouseDown`, `onMouseUp` and `onTouchEnd` to that same DOM node.
+ * 3. Adds some special sauce to prevent clicks from being triggered when dragging.
  *
  * @see https://github.com/react-grid-layout/react-grid-layout?tab=readme-ov-file#custom-child-components-and-draggable-handles
  */
-const RGLHandle = React.forwardRef<HTMLDivElement, RGLHandleProps>(
+const RGLNode = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & {
+    children?: React.ReactNode;
+    debug?: boolean;
+    dragging: boolean;
+    setDragging: (dragging: boolean) => void;
+  }
+>(
   (
-    {
-      style,
-      className,
-      onMouseDown,
-      onMouseUp,
-      onTouchEnd,
-      children,
-      debug = false,
-      dragging,
-      setDragging,
-      ...props
-    },
+    { className, children, debug = false, dragging, setDragging, ...props },
     ref
   ) => {
     return (
       <div
-        style={style}
+        ref={ref}
         className={cn(
           debug && 'border-divider rounded-2xl border-2 border-dashed',
           className
         )}
-        ref={ref}
-        onMouseDown={onMouseDown}
-        onMouseUp={onMouseUp}
-        onTouchEnd={onTouchEnd}
         onClick={(e) => {
           dragging && e.preventDefault();
           setDragging(false);
@@ -178,12 +167,12 @@ const RGLHandle = React.forwardRef<HTMLDivElement, RGLHandleProps>(
   }
 );
 
-RGLHandle.displayName = 'WidgetRGLHandle';
+RGLNode.displayName = 'RGLNode';
 
 /**
  * Render widget controls and a delete button over a widget
  *
- * Should be rendered in a container that is the size of the widget, with `group` and `relative` classes
+ * Should be rendered in a container that is the size of the widget, with `group/widget` and `relative` classes
  */
 const ControlOverlay = ({
   widget,

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -238,7 +238,7 @@ const ControlOverlay = ({
       </div>
       <div
         className={cn(
-          'absolute left-0 top-0 -translate-x-3 -translate-y-1/2', // position
+          'absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/3', // position
           'opacity-0 transition-opacity duration-300', // opacity
           !dragging && 'group-hover/widget:opacity-100' // hover (only if not dragged)
         )}

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -207,7 +207,7 @@ const ControlOverlay = ({
       <div
         className={cn(
           'absolute bottom-0 left-1/2 w-fit -translate-x-1/2 translate-y-1/2', // position
-          'opacity-0 transition-opacity duration-300', // opacity
+          'opacity-0 transition-opacity duration-300 ease-out', // opacity
           !dragging && 'group-hover/widget:opacity-100', // hover (only if not dragged)
           isPopoverOpen && 'opacity-100' // show when popover is open
         )}
@@ -225,7 +225,7 @@ const ControlOverlay = ({
       <div
         className={cn(
           'absolute right-0 top-0 -translate-y-1/3 translate-x-1/3', // position
-          'opacity-0 transition-opacity duration-300', // opacity
+          'opacity-0 transition-opacity duration-300 ease-out', // opacity
           !dragging && 'group-hover/widget:opacity-100', // hover (only if not dragged)
           isPopoverOpen && 'opacity-100' // show when popover is open
         )}

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -5,7 +5,6 @@ import React, { useEffect, useState } from 'react';
 import { Responsive as RRGL } from 'react-grid-layout';
 
 import { WidgetData } from '@/api/widgets-v2/types';
-import { PreviewControls } from '@/app/[handle]/components/widget/widget-controls/preview-controls';
 import { useContainerQuery } from '@/hooks/use-container-query';
 import { cn } from '@/lib/utils';
 
@@ -104,6 +103,7 @@ export const WidgetGrid = ({ immutable = false }: { immutable?: boolean }) => {
                 <Widget
                   {...widget}
                   size={s}
+                  isDragging={isDragging}
                   editable={!immutable}
                   showPlaceholder={!immutable}
                   onUpdate={(data) => updateWidget(widget.id, data)}
@@ -196,38 +196,10 @@ const ControlOverlay = ({
   dragging: boolean;
   controls?: Control[];
 }) => {
-  const { updateSize, removeWidget, updateWidget, updatePreview } =
-    useWidgets();
+  const { updateSize, removeWidget, updateWidget } = useWidgets();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
 
-  const showPreviewControls =
-    size !== 'B' && size !== 'E' && !controls?.includes('link');
-
-  const { id, href, hideContent, userContentUrl, contentUrl } = widget;
-
-  // Build conditionally available functions to handle actions on the preview controls as well as control their visibility
-  const showDelete =
-    !hideContent && (contentUrl !== null || userContentUrl !== null);
-  const showRevert =
-    userContentUrl !== null || (contentUrl !== null && hideContent);
-  const showUpload = true; // always can upload a new image
-  const handleUpload = showUpload
-    ? (image: File) => updatePreview(id, image)
-    : undefined;
-  const handleRevert = showRevert
-    ? () =>
-        updateWidget(id, {
-          userContentUrl: null,
-          hideContent: false,
-        })
-    : undefined;
-  const handleDelete = showDelete
-    ? () =>
-        updateWidget(id, {
-          userContentUrl: null,
-          hideContent: true,
-        })
-    : undefined;
+  const { id, href } = widget;
 
   // Containers implement hover behavior and position absolutely
   return (
@@ -259,21 +231,6 @@ const ControlOverlay = ({
         )}
       >
         <WidgetDeleteButton onDelete={() => removeWidget(id)} />
-      </div>
-      <div
-        className={cn(
-          'absolute right-0 top-1/2 -translate-y-1/2 translate-x-1/3', // position
-          'opacity-0 transition-opacity duration-300', // opacity
-          !dragging && 'group-hover/widget:opacity-100' // hover (only if not dragged)
-        )}
-      >
-        {showPreviewControls && (
-          <PreviewControls
-            onUpload={handleUpload}
-            onRevert={handleRevert}
-            onDelete={handleDelete}
-          />
-        )}
       </div>
     </>
   );

--- a/src/app/[handle]/components/widget/grid.tsx
+++ b/src/app/[handle]/components/widget/grid.tsx
@@ -3,7 +3,9 @@ import 'react-resizable/css/styles.css';
 
 import React, { useEffect, useState } from 'react';
 import { Responsive as RRGL } from 'react-grid-layout';
+import { toast } from 'sonner';
 
+import { PreviewControls } from '@/app/[handle]/components/widget/widget-controls/preview-controls';
 import { useContainerQuery } from '@/hooks/use-container-query';
 import { cn } from '@/lib/utils';
 
@@ -199,7 +201,25 @@ const ControlOverlay = ({
 }) => {
   const { updateSize, removeWidget, updateWidget } = useWidgets();
   const [isPopoverOpen, setIsPopoverOpen] = useState(false);
-  // within containers to prevent clicks from being passed down to RGL, hover to show correctly, and position absolutely
+
+  const showPreviewControls =
+    size !== 'B' && size !== 'E' && !controls?.includes('link');
+
+  // const handleDelete = () => {
+  //   toast('Deleting image');
+  //   updateWidget(id, { userContentUrl: null, hideContent: true });
+  // };
+  // const handleUpload = (image) => {
+  //   // set contentUrl to local url, set image loading to true, do upload, and replace url when done
+  //   updatePreview(id, { image });
+  //   toast('Uploading image');
+  // };
+  // const handleRevert = () => {
+  //   toast('Reverting image');
+  //   updateWidget(id, { userContentUrl: null, hideContent: false });
+  // };
+
+  // Containers implement hover behavior and position absolutely
   return (
     <>
       <div
@@ -209,7 +229,6 @@ const ControlOverlay = ({
           !dragging && 'group-hover/widget:opacity-100', // hover (only if not dragged)
           isPopoverOpen && 'opacity-100' // show when popover is open
         )}
-        onMouseDown={(e) => e.stopPropagation()}
       >
         <WidgetControls
           size={size}
@@ -228,9 +247,29 @@ const ControlOverlay = ({
           !dragging && 'group-hover/widget:opacity-100', // hover (only if not dragged)
           isPopoverOpen && 'opacity-100' // show when popover is open
         )}
-        onMouseDown={(e) => e.stopPropagation()}
       >
         <WidgetDeleteButton onDelete={() => removeWidget(id)} />
+      </div>
+      <div
+        className={cn(
+          'absolute left-0 top-0 -translate-x-3 -translate-y-1/2', // position
+          'opacity-0 transition-opacity duration-300', // opacity
+          !dragging && 'group-hover/widget:opacity-100' // hover (only if not dragged)
+        )}
+      >
+        {showPreviewControls && (
+          <PreviewControls
+            onUpload={() => {
+              toast('upload');
+            }}
+            onRevert={() => {
+              toast('revert');
+            }}
+            onDelete={() => {
+              toast('delete');
+            }}
+          />
+        )}
       </div>
     </>
   );

--- a/src/app/[handle]/components/widget/widget-controls/control-button.tsx
+++ b/src/app/[handle]/components/widget/widget-controls/control-button.tsx
@@ -23,7 +23,11 @@ export const ControlButton = forwardRef<
         isActive && 'bg-[#D0ADFF] text-[#18181B]', // --purple-lightest
         !isActive && 'hover:bg-[#D0ADFF]/30'
       )}
-      onClick={onClick}
+      onClick={(e) => {
+        e.stopPropagation();
+        e.preventDefault();
+        onClick?.();
+      }}
       {...props}
     >
       {children}

--- a/src/app/[handle]/components/widget/widget-controls/control-button.tsx
+++ b/src/app/[handle]/components/widget/widget-controls/control-button.tsx
@@ -4,6 +4,7 @@ import { cn } from '@/lib/utils';
 
 /**
  * Base button for widget controls.
+ * - Prevents event default to avoid triggering opening parent a tag (widget root)
  * TODO: Use design tokens
  */
 export const ControlButton = forwardRef<
@@ -24,7 +25,6 @@ export const ControlButton = forwardRef<
         !isActive && 'hover:bg-[#D0ADFF]/30'
       )}
       onClick={(e) => {
-        e.stopPropagation();
         e.preventDefault();
         onClick?.();
       }}

--- a/src/app/[handle]/components/widget/widget-controls/preview-controls.stories.tsx
+++ b/src/app/[handle]/components/widget/widget-controls/preview-controls.stories.tsx
@@ -1,0 +1,23 @@
+import { Meta, StoryObj } from '@storybook/react';
+import { fn } from '@storybook/test';
+
+import { PreviewControls } from './preview-controls';
+
+const meta = {
+  title: 'Profile/PreviewControls',
+  component: PreviewControls,
+  parameters: {
+    layout: 'centered',
+  },
+  args: {
+    onUpload: fn(),
+    onRevert: fn(),
+    onDelete: fn(),
+  },
+} satisfies Meta<typeof PreviewControls>;
+
+export default meta;
+
+type Story = StoryObj<typeof PreviewControls>;
+
+export const Default: Story = {};

--- a/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
+++ b/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
@@ -65,6 +65,7 @@ export const PreviewControls = ({
               <InvisibleInput
                 handleInputChange={handleInputChange}
                 inputProps={{ accept: validImageExtensionsWithDots.join(',') }}
+                className='cursor-pointer'
               >
                 <ImageIcon className='size-4' />
               </InvisibleInput>

--- a/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
+++ b/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
@@ -60,16 +60,14 @@ export const PreviewControls = ({
       {showUpload && (
         <Tooltip>
           <TooltipTrigger asChild>
-            {/* TODO: Button and input can be focused here, fix this */}
-            <ControlButton>
-              <InvisibleInput
-                handleInputChange={handleInputChange}
-                inputProps={{ accept: validImageExtensionsWithDots.join(',') }}
-                className='cursor-pointer'
-              >
-                <ImageIcon className='size-4' />
-              </InvisibleInput>
-            </ControlButton>
+            <InvisibleInput
+              handleInputChange={handleInputChange}
+              inputProps={{ accept: validImageExtensionsWithDots.join(',') }}
+              // TODO: These styles are duplication of ControlButton styles
+              className='text-primary-foreground flex size-6 min-w-fit cursor-pointer items-center justify-center rounded-sm transition-colors hover:bg-[#D0ADFF]/30'
+            >
+              <ImageIcon className='size-4' />
+            </InvisibleInput>
           </TooltipTrigger>
           <TooltipContent side='top' sideOffset={8}>
             <p>Upload custom image</p>

--- a/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
+++ b/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
@@ -20,6 +20,8 @@ import { ControlContainer } from './control-container';
 
 /**
  * Controls for the preview image of a widget. Allowing delete, custom upload, and revert.
+ *
+ * To hide an action, pass undefined for its callback.
  */
 export const PreviewControls = ({
   className,
@@ -32,10 +34,9 @@ export const PreviewControls = ({
   onRevert?: () => void;
   onDelete?: () => void;
 }) => {
-  // Could be props
-  const showUpload = true;
-  const showRevert = true;
-  const showDelete = true;
+  const showUpload = Boolean(onUpload);
+  const showRevert = Boolean(onRevert);
+  const showDelete = Boolean(onDelete);
 
   // TODO: Consider sharing this fn with control bar
   // Handle an image picked from the file system

--- a/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
+++ b/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
@@ -119,7 +119,9 @@ export const PreviewControlsConnected = ({
 }) => {
   const { hideContent, contentUrl, userContentUrl, id } = widget;
   const showDelete = Boolean(!hideContent && (contentUrl || userContentUrl));
-  const showRevert = Boolean(userContentUrl || (contentUrl && !hideContent));
+  const showRevert = Boolean(
+    (userContentUrl && contentUrl) || (contentUrl && hideContent)
+  );
   const showUpload = true; // always can upload a new image
 
   const { updatePreview, updateWidget } = useWidgets();

--- a/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
+++ b/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
@@ -44,7 +44,6 @@ export const PreviewControls = ({
   // TODO: Consider sharing this fn with control bar
   // Handle an image picked from the file system
   const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    e.stopPropagation();
     // Only support the first file (input should limit anyway)
     const file = e.target.files?.[0];
     if (checkFileValid(file)) {
@@ -64,7 +63,14 @@ export const PreviewControls = ({
     <ControlContainer className={className}>
       {showUpload && (
         <Tooltip>
-          <TooltipTrigger asChild>
+          <TooltipTrigger
+            asChild
+            onMouseDown={(e) => {
+              // Don't understand why, but this fixes a bug where
+              // When a file is selected, or the file browser is closed, the tooltip is held open
+              e.preventDefault();
+            }}
+          >
             <InvisibleInput
               handleInputChange={handleInputChange}
               inputProps={{ accept: validImageExtensionsWithDots.join(',') }}

--- a/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
+++ b/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
@@ -1,0 +1,105 @@
+'use client';
+
+import { ImageIcon, ImageOff, Trash2 } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { InvisibleInput } from '@/app/[handle]/components/control-bar/invisible-input';
+import { ControlButton } from '@/app/[handle]/components/widget/widget-controls/control-button';
+import {
+  validImageExtensions,
+  validImageExtensionsWithDots,
+} from '@/components/profile/widgets/util';
+import { checkFileValid } from '@/components/profile/widgets/util';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
+
+import { ControlContainer } from './control-container';
+
+/**
+ * Controls for the preview image of a widget. Allowing delete, custom upload, and revert.
+ */
+export const PreviewControls = ({
+  className,
+  onUpload,
+  onRevert,
+  onDelete,
+}: {
+  className?: string;
+  onUpload?: (image: File) => void;
+  onRevert?: () => void;
+  onDelete?: () => void;
+}) => {
+  // Could be props
+  const showUpload = true;
+  const showRevert = true;
+  const showDelete = true;
+
+  // TODO: Consider sharing this fn with control bar
+  // Handle an image picked from the file system
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // Only support the first file (input should limit anyway)
+    const file = e.target.files?.[0];
+    if (checkFileValid(file)) {
+      onUpload?.(file);
+      e.target.value = '';
+    } else {
+      // This should only ever toast with 10mb error (since the input only accepts valid extensions)
+      toast.error("We couldn't add this image", {
+        description: `Images must be smaller than 10MB and be on the following formats: ${validImageExtensions.join(
+          ', '
+        )}`,
+      });
+    }
+  };
+
+  return (
+    <ControlContainer className={className}>
+      {showUpload && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            {/* TODO: Button and input can be focused here, fix this */}
+            <ControlButton>
+              <InvisibleInput
+                handleInputChange={handleInputChange}
+                inputProps={{ accept: validImageExtensionsWithDots.join(',') }}
+              >
+                <ImageIcon className='size-4' />
+              </InvisibleInput>
+            </ControlButton>
+          </TooltipTrigger>
+          <TooltipContent side='top' sideOffset={8}>
+            <p>Upload custom image</p>
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {showRevert && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <ControlButton onClick={onRevert}>
+              <ImageOff className='size-4' />
+            </ControlButton>
+          </TooltipTrigger>
+          <TooltipContent side='top' sideOffset={8}>
+            <p>Use website preview</p>
+          </TooltipContent>
+        </Tooltip>
+      )}
+      {/* TODO: Could use a compact delete button, but need it be forwardRef and size 4 */}
+      {showDelete && (
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <ControlButton onClick={onDelete}>
+              <Trash2 className='size-4' />
+            </ControlButton>
+          </TooltipTrigger>
+          <TooltipContent side='top' sideOffset={8}>
+            <p className='text-destructive'>Delete image</p>
+          </TooltipContent>
+        </Tooltip>
+      )}
+    </ControlContainer>
+  );
+};

--- a/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
+++ b/src/app/[handle]/components/widget/widget-controls/preview-controls.tsx
@@ -22,8 +22,7 @@ import { ControlContainer } from './control-container';
 
 /**
  * Controls for the preview image of a widget. Allowing delete, custom upload, and revert.
- *
- * To hide an action, pass undefined for its callback.
+ * - Each action has a corresponding callback and a boolean to show/hide.
  */
 export const PreviewControls = ({
   className,
@@ -109,8 +108,13 @@ export const PreviewControls = ({
   );
 };
 
-// Connect Preview control UI to widget state and actions
-export const PreviewControlsConnected = ({
+/**
+ * Connect Preview control UI to widget state and actions
+ * - Hide and show actions based on the widget props this component receives
+ * - Connect action callbacks to `useWidgets`
+ * - Make sure to use within `WidgetContext`
+ */
+export const ConnectedPreviewControls = ({
   widget,
 }: {
   widget: Partial<

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -3,17 +3,17 @@ import React from 'react';
 import { parseURL } from 'ufo';
 
 import { UpdateWidgetDto, WidgetData } from '@/api/widgets-v2';
-import { WidgetSize } from '@/app/[handle]/components/widget/grid-config';
-import { PreviewControlsConnected } from '@/app/[handle]/components/widget/widget-controls/preview-controls';
 import { InlineEdit } from '@/components/common/inline-edit/inline-edit';
 import { Spinner } from '@/components/common/spinner';
 import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
 
+import { WidgetSize } from './grid-config';
 import { ImageWidget } from './image-widget';
 import { SocialIcon } from './social-icon';
 import { getUrlType } from './url-util';
+import { ConnectedPreviewControls } from './widget-controls/preview-controls';
 
 export type WidgetProps = Partial<WidgetData> & {
   loading?: boolean;
@@ -180,7 +180,7 @@ export const Widget = ({
                   !isDragging && 'group-hover/preview:opacity-100' // hover (only if not dragged)
                 )}
               >
-                <PreviewControlsConnected widget={{ ...props, id }} />
+                <ConnectedPreviewControls widget={{ ...props, id }} />
               </div>
             )}
           </div>

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -41,13 +41,24 @@ export const Widget = ({
   // We store widgets state as nullable for good reason.
   // So the easiest way to handle this is to just accept null and undefined props.
   // And convert here for convenience below.
-  const { href, contentUrl, iconUrl, title, userTitle, type } = {
+  const {
+    href,
+    contentUrl,
+    iconUrl,
+    title,
+    userTitle,
+    type,
+    userContentUrl,
+    hideContent,
+  } = {
     href: props.href ?? undefined,
     contentUrl: props.contentUrl ?? undefined,
     iconUrl: props.iconUrl ?? undefined,
     title: props.title ?? undefined,
     userTitle: props.userTitle ?? undefined,
     type: props.type ?? undefined,
+    userContentUrl: props.userContentUrl ?? undefined,
+    hideContent: props.hideContent ?? undefined,
   };
 
   if (type === 'image') {
@@ -66,6 +77,9 @@ export const Widget = ({
   // This is the title of the widget if the user has not explicitly set a title.
   // If the user has set userTitle, it will be preferred. If they clear that, we will fall back to this.
   const fallbackTitle = title || parseURL(href).host || href || '';
+
+  // userContentUrl overrides contentUrl, hideContent overrides both
+  const _contentUrl = hideContent ? undefined : userContentUrl || contentUrl;
 
   return (
     <a
@@ -137,9 +151,9 @@ export const Widget = ({
           >
             {loading ? (
               <Skeleton className='size-full' />
-            ) : contentUrl ? (
+            ) : _contentUrl ? (
               <img
-                src={contentUrl}
+                src={_contentUrl}
                 alt={title}
                 className='size-full rounded-md object-cover'
               />

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -176,7 +176,7 @@ export const Widget = ({
               <div
                 className={cn(
                   'absolute left-0 top-0 -translate-x-[0.75rem] -translate-y-1/2', // position
-                  'opacity-0 transition-opacity duration-300', // opacity
+                  'opacity-0 transition-opacity duration-300 ease-out', // opacity
                   !isDragging && 'group-hover/preview:opacity-100' // hover (only if not dragged)
                 )}
               >

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -22,7 +22,7 @@ export type WidgetProps = Partial<WidgetData> & {
   editable?: boolean;
   onUpdate?: (data: UpdateWidgetDto) => void;
   showPlaceholder?: boolean;
-  isDragging?: boolean;
+  dragging?: boolean;
 };
 
 /**
@@ -39,7 +39,7 @@ export const Widget = ({
   previewLoading = false,
   size = 'A',
   editable = false,
-  isDragging = false,
+  dragging = false,
   onUpdate,
   showPlaceholder = true,
   id,
@@ -177,7 +177,7 @@ export const Widget = ({
                 className={cn(
                   'absolute left-0 top-0 -translate-x-[0.75rem] -translate-y-1/2', // position
                   'opacity-0 transition-opacity duration-300 ease-out', // opacity
-                  !isDragging && 'group-hover/preview:opacity-100' // hover (only if not dragged)
+                  !dragging && 'group-hover/preview:opacity-100' // hover (only if not dragged)
                 )}
               >
                 <ConnectedPreviewControls widget={{ ...props, id }} />

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -5,6 +5,7 @@ import { parseURL } from 'ufo';
 import { UpdateWidgetDto, WidgetData } from '@/api/widgets-v2';
 import { WidgetSize } from '@/app/[handle]/components/widget/grid-config';
 import { InlineEdit } from '@/components/common/inline-edit/inline-edit';
+import { Spinner } from '@/components/common/spinner';
 import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
@@ -15,6 +16,7 @@ import { getUrlType } from './url-util';
 
 export type WidgetProps = Partial<Omit<WidgetData, 'id'>> & {
   loading?: boolean;
+  previewLoading?: boolean;
   size: WidgetSize;
   editable?: boolean;
   onUpdate?: (data: UpdateWidgetDto) => void;
@@ -32,6 +34,7 @@ export type WidgetProps = Partial<Omit<WidgetData, 'id'>> & {
  */
 export const Widget = ({
   loading = false,
+  previewLoading = false,
   size = 'A',
   editable = false,
   onUpdate,
@@ -144,6 +147,7 @@ export const Widget = ({
         >
           <div
             className={cn(
+              'relative',
               size === 'A' && 'aspect-[1200/630] w-full',
               size === 'C' && 'aspect-square w-full',
               size === 'D' && 'aspect-square h-full'
@@ -160,6 +164,7 @@ export const Widget = ({
             ) : showPlaceholder ? (
               <ContentPlaceholder className='size-full' />
             ) : null}
+            {previewLoading && <Spinner className='absolute left-3 top-3' />}
           </div>
         </CardContent>
       )}

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -89,7 +89,7 @@ export const Widget = ({
   const _contentUrl = hideContent ? undefined : userContentUrl || contentUrl;
 
   const showPreviewControls =
-    id && size !== 'B' && size !== 'E' && type !== 'image';
+    editable && id && size !== 'B' && size !== 'E' && type !== 'image';
 
   return (
     <a

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -4,6 +4,7 @@ import { parseURL } from 'ufo';
 
 import { UpdateWidgetDto, WidgetData } from '@/api/widgets-v2';
 import { WidgetSize } from '@/app/[handle]/components/widget/grid-config';
+import { PreviewControlsConnected } from '@/app/[handle]/components/widget/widget-controls/preview-controls';
 import { InlineEdit } from '@/components/common/inline-edit/inline-edit';
 import { Spinner } from '@/components/common/spinner';
 import { CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -14,13 +15,14 @@ import { ImageWidget } from './image-widget';
 import { SocialIcon } from './social-icon';
 import { getUrlType } from './url-util';
 
-export type WidgetProps = Partial<Omit<WidgetData, 'id'>> & {
+export type WidgetProps = Partial<WidgetData> & {
   loading?: boolean;
   previewLoading?: boolean;
   size: WidgetSize;
   editable?: boolean;
   onUpdate?: (data: UpdateWidgetDto) => void;
   showPlaceholder?: boolean;
+  isDragging?: boolean;
 };
 
 /**
@@ -37,8 +39,10 @@ export const Widget = ({
   previewLoading = false,
   size = 'A',
   editable = false,
+  isDragging = false,
   onUpdate,
   showPlaceholder = true,
+  id,
   ...props
 }: WidgetProps) => {
   // We store widgets state as nullable for good reason.
@@ -84,10 +88,13 @@ export const Widget = ({
   // userContentUrl overrides contentUrl, hideContent overrides both
   const _contentUrl = hideContent ? undefined : userContentUrl || contentUrl;
 
+  const showPreviewControls =
+    id && size !== 'B' && size !== 'E' && type !== 'image';
+
   return (
     <a
       className={cn(
-        'bg-card text-card-foreground flex select-none flex-col overflow-clip rounded-2xl border shadow-sm',
+        'bg-card text-card-foreground flex select-none flex-col overflow-hidden rounded-2xl border shadow-sm',
         size === 'D' && 'flex-row',
         size === 'E' && 'justify-center',
         'size-full max-h-[390px] max-w-[390px]',
@@ -147,7 +154,7 @@ export const Widget = ({
         >
           <div
             className={cn(
-              'relative',
+              'group/preview relative',
               size === 'A' && 'aspect-[1200/630] w-full',
               size === 'C' && 'aspect-square w-full',
               size === 'D' && 'aspect-square h-full'
@@ -164,7 +171,18 @@ export const Widget = ({
             ) : showPlaceholder ? (
               <ContentPlaceholder className='size-full' />
             ) : null}
-            {previewLoading && <Spinner className='absolute left-3 top-3' />}
+            {previewLoading && <Spinner className='absolute right-3 top-3' />}
+            {showPreviewControls && (
+              <div
+                className={cn(
+                  'absolute left-0 top-0 -translate-x-[0.75rem] -translate-y-1/2', // position
+                  'opacity-0 transition-opacity duration-300', // opacity
+                  !isDragging && 'group-hover/preview:opacity-100' // hover (only if not dragged)
+                )}
+              >
+                <PreviewControlsConnected widget={{ ...props, id }} />
+              </div>
+            )}
           </div>
         </CardContent>
       )}

--- a/src/app/[handle]/components/widget/widget.tsx
+++ b/src/app/[handle]/components/widget/widget.tsx
@@ -51,21 +51,21 @@ export const Widget = ({
   const {
     href,
     contentUrl,
+    userContentUrl,
+    hideContent,
     iconUrl,
     title,
     userTitle,
     type,
-    userContentUrl,
-    hideContent,
   } = {
     href: props.href ?? undefined,
     contentUrl: props.contentUrl ?? undefined,
+    userContentUrl: props.userContentUrl ?? undefined,
+    hideContent: props.hideContent ?? undefined,
     iconUrl: props.iconUrl ?? undefined,
     title: props.title ?? undefined,
     userTitle: props.userTitle ?? undefined,
     type: props.type ?? undefined,
-    userContentUrl: props.userContentUrl ?? undefined,
-    hideContent: props.hideContent ?? undefined,
   };
 
   if (type === 'image') {

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -15,6 +15,7 @@ const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>
 >(({ className, sideOffset = 4, ...props }, ref) => (
+  <TooltipPrimitive.Portal>
   <TooltipPrimitive.Content
     ref={ref}
     sideOffset={sideOffset}
@@ -25,6 +26,7 @@ const TooltipContent = React.forwardRef<
     )}
     {...props}
   />
+  </TooltipPrimitive.Portal>
 ))
 TooltipContent.displayName = TooltipPrimitive.Content.displayName
 


### PR DESCRIPTION
**Changes**

- Abstract out and share InvisibleInput
- Add and render `PreviewControls` in `Widget`
- Add `userContentUrl` and `hideContent` to widget data
- `mockUpdateWidgetHandler` updates all widget data
- `ControlButton`s prevent default to avoid clicking widgets underneath
- Refactoring and renaming in `grid` to increase clarity
- Use `ease-out` curves for controls
- Add `updatePreview` to `WidgetContext` to allow the updating of a preview image with automatic image upload
- `updateWidgetMutation` will abort in progress image uploads if userContentUrl goes to null
- `Widget` will prefer `userContentUrl` over `contentUrl` similar to `usertTitle`. `hideContent` will override both.
- add `MineDisableMSW` story
- Add missing Portal to `tooltip`